### PR TITLE
Fix Vulkan errors when closing the application

### DIFF
--- a/Build/updateExamplesDependencies.bat
+++ b/Build/updateExamplesDependencies.bat
@@ -40,12 +40,10 @@ git clone https://github.com/LIONant-depot/xtexture.plugin "../dependencies/xtex
 if %ERRORLEVEL% GEQ 1 goto :ERROR
 cd ../dependencies/xtexture.plugin/build
 if %ERRORLEVEL% GEQ 1 goto :ERROR
-call updateDependencies.bat "return"
+call CreateProject.bat "return"
 if %ERRORLEVEL% GEQ 1 goto :ERROR
 
-rem now let us build
-call build_versions.bat "return"
-if %ERRORLEVEL% GEQ 1 goto :ERROR
+rem assume this builds automatically
 cd /d %XGPU_PATH%
 if %ERRORLEVEL% GEQ 1 goto :ERROR
 

--- a/Src/Details/System/Windows/xgpu_windows.h
+++ b/Src/Details/System/Windows/xgpu_windows.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #define NOMINMAX
-#include<windows.h>
+#include <windows.h>
 
 #include "xgpu_windows_localstorage.h"
 #include "xgpu_windows_keyboard.h"

--- a/Src/Details/Vulkan/xgpu_vulkan_buffer.cpp
+++ b/Src/Details/Vulkan/xgpu_vulkan_buffer.cpp
@@ -310,7 +310,7 @@ namespace xgpu::vulkan
 
     //----------------------------------------------------------------------------------
 
-    void buffer::Destroy(void) noexcept
+    void buffer::Destroy( void ) noexcept
     {
 
         if(m_pVMapMemory)
@@ -330,5 +330,12 @@ namespace xgpu::vulkan
             vkFreeMemory(m_Device->m_VKDevice, m_VKBufferMemory, m_Device->m_Instance->m_pVKAllocator );
             m_VKBufferMemory = VK_NULL_HANDLE;
         }
+    }
+
+    void buffer::DeathMarch(xgpu::buffer&& Buffer) noexcept
+    {
+        if (!m_Device) return;
+        m_Device->Destroy(std::move(Buffer));
+        m_Device.reset();
     }
 }

--- a/Src/Details/Vulkan/xgpu_vulkan_buffer.cpp
+++ b/Src/Details/Vulkan/xgpu_vulkan_buffer.cpp
@@ -268,7 +268,7 @@ namespace xgpu::vulkan
 
     buffer::~buffer(void) noexcept
     {
-        Destroy();
+
     }
 
     //-------------------------------------------------------------------------------
@@ -312,6 +312,7 @@ namespace xgpu::vulkan
 
     void buffer::Destroy(void) noexcept
     {
+
         if(m_pVMapMemory)
         {
             vkUnmapMemory(m_Device->m_VKDevice, m_VKBufferMemory);

--- a/Src/Details/Vulkan/xgpu_vulkan_buffer.h
+++ b/Src/Details/Vulkan/xgpu_vulkan_buffer.h
@@ -12,7 +12,8 @@ namespace xgpu::vulkan
                 xgpu::device::error*    Create                  ( const xgpu::buffer::setup& Setup )                                    noexcept;
                 void                    Destroy                 ( void )                                                                noexcept;
                 void*                   getUniformBufferVMem    ( std::uint32_t& DynamicOffset )                                        noexcept;
-
+                
+        virtual void                    DeathMarch              ( xgpu::buffer&& buffer )                                               noexcept override;
 
         std::shared_ptr<device>     m_Device            {};
         std::atomic<int>            m_CurrentOffset     {};     // For uniform buffers

--- a/Src/Details/Vulkan/xgpu_vulkan_buffer.h
+++ b/Src/Details/Vulkan/xgpu_vulkan_buffer.h
@@ -7,8 +7,7 @@ namespace xgpu::vulkan
         virtual xgpu::device::error*    MapLock                 ( void*& pMemory, int StartIndex, int Count )                           noexcept override;
         virtual xgpu::device::error*    MapUnlock               ( int StartIndex, int Count )                                           noexcept override;
         virtual int                     getEntryCount           ( void ) const                                                          noexcept override;
-        virtual xgpu::buffer::error*    Resize            ( int NewEntryCount )                                                   noexcept override;
-
+        virtual xgpu::buffer::error*    Resize                  ( int NewEntryCount )                                                   noexcept override;
                 xgpu::device::error*    TransferToDestination   ( void )                                                                noexcept;
                 xgpu::device::error*    Create                  ( const xgpu::buffer::setup& Setup )                                    noexcept;
                 void                    Destroy                 ( void )                                                                noexcept;

--- a/Src/Details/Vulkan/xgpu_vulkan_device.cpp
+++ b/Src/Details/Vulkan/xgpu_vulkan_device.cpp
@@ -4,28 +4,28 @@ namespace xgpu::vulkan
     //----------------------------------------------------------------------------------------------------------
 
     xgpu::device::error* CreateGraphicsDevice
-    ( device&                                       Device
-    , const bool                                    enableValidation
-    , const std::vector<VkQueueFamilyProperties>&   DeviceProperties 
+    (device& Device
+        , const bool                                    enableValidation
+        , const std::vector<VkQueueFamilyProperties>& DeviceProperties
     ) noexcept
     {
         //
         // Lets find a transfer queue... because we are going to let assets transfer at lighting speed
         // (So async transfers)
-        for( auto i=0u; i<DeviceProperties.size(); ++i )
+        for (auto i = 0u; i < DeviceProperties.size(); ++i)
         {
             // We want to find a queue that is not compute, or graphics
             // we just need to transfer
-            if(    (DeviceProperties[i].queueFlags & VK_QUEUE_TRANSFER_BIT) 
-                && ( Device.m_MainQueueIndex != i )
-              )
+            if ((DeviceProperties[i].queueFlags & VK_QUEUE_TRANSFER_BIT)
+                && (Device.m_MainQueueIndex != i)
+                )
             {
                 Device.m_TransferQueueIndex = i;
                 break;
             }
         }
 
-        if( Device.m_TransferQueueIndex == 0xffffffff )
+        if (Device.m_TransferQueueIndex == 0xffffffff)
         {
             Device.m_Instance->ReportError("Unable to find a transfer only queue");
             return VGPU_ERROR(xgpu::device::error::FAILURE, "Unable to find a transfer only queue");
@@ -34,21 +34,21 @@ namespace xgpu::vulkan
         //
         // Prepare our queues
         //
-        static const std::array     queuePriorities    = {    0.0f };
+        static const std::array     queuePriorities = { 0.0f };
         auto queueCreateInfo = std::array
-        {   VkDeviceQueueCreateInfo 
+        { VkDeviceQueueCreateInfo
             {
-                .sType              = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO
-            ,   .queueFamilyIndex   = Device.m_MainQueueIndex
-            ,   .queueCount         = static_cast<std::uint32_t>(queuePriorities.size())
-            ,   .pQueuePriorities   = queuePriorities.data()
+                .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO
+            ,   .queueFamilyIndex = Device.m_MainQueueIndex
+            ,   .queueCount = static_cast<std::uint32_t>(queuePriorities.size())
+            ,   .pQueuePriorities = queuePriorities.data()
             }
         ,   VkDeviceQueueCreateInfo
             {
-                .sType              = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO
-            ,   .queueFamilyIndex   = Device.m_TransferQueueIndex
-            ,   .queueCount         = static_cast<std::uint32_t>(queuePriorities.size())
-            ,   .pQueuePriorities   = queuePriorities.data()
+                .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO
+            ,   .queueFamilyIndex = Device.m_TransferQueueIndex
+            ,   .queueCount = static_cast<std::uint32_t>(queuePriorities.size())
+            ,   .pQueuePriorities = queuePriorities.data()
             }
         };
 
@@ -56,44 +56,44 @@ namespace xgpu::vulkan
         // Create device now
         //
         VkPhysicalDeviceFeatures Features{};
-        vkGetPhysicalDeviceFeatures( Device.m_VKPhysicalDevice, &Features );
+        vkGetPhysicalDeviceFeatures(Device.m_VKPhysicalDevice, &Features);
         Features.shaderClipDistance = true;
         Features.shaderCullDistance = true;
-        Features.samplerAnisotropy  = true;
+        Features.samplerAnisotropy = true;
 
-        static constexpr auto       enabledExtensions   = std::array
-        { 
+        static constexpr auto       enabledExtensions = std::array
+        {
             VK_KHR_SWAPCHAIN_EXTENSION_NAME
-//        ,   VK_NV_GLSL_SHADER_EXTENSION_NAME  // nVidia useful extension to be able to load GLSL shaders
+            //        ,   VK_NV_GLSL_SHADER_EXTENSION_NAME  // nVidia useful extension to be able to load GLSL shaders
         };
         VkDeviceCreateInfo          deviceCreateInfo
         {
-            .sType                      = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO
-        ,   .pNext                      = nullptr
-        ,   .queueCreateInfoCount       = static_cast<uint32_t>(queueCreateInfo.size())
-        ,   .pQueueCreateInfos          = queueCreateInfo.data()
-        ,   .enabledLayerCount          = 0
-        ,   .ppEnabledLayerNames        = nullptr
-        ,   .enabledExtensionCount      = static_cast<uint32_t>(enabledExtensions.size())
-        ,   .ppEnabledExtensionNames    = enabledExtensions.data()
-        ,   .pEnabledFeatures           = &Features
+            .sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO
+        ,   .pNext = nullptr
+        ,   .queueCreateInfoCount = static_cast<uint32_t>(queueCreateInfo.size())
+        ,   .pQueueCreateInfos = queueCreateInfo.data()
+        ,   .enabledLayerCount = 0
+        ,   .ppEnabledLayerNames = nullptr
+        ,   .enabledExtensionCount = static_cast<uint32_t>(enabledExtensions.size())
+        ,   .ppEnabledExtensionNames = enabledExtensions.data()
+        ,   .pEnabledFeatures = &Features
         };
 
         std::vector<const char*>    ValidationLayers{};
-        if( Device.m_Instance->m_bValidation )
+        if (Device.m_Instance->m_bValidation)
         {
-            ValidationLayers = getValidationLayers( *Device.m_Instance );
-            deviceCreateInfo.enabledLayerCount          = static_cast<std::uint32_t>(ValidationLayers.size());
-            deviceCreateInfo.ppEnabledLayerNames        = ValidationLayers.data();
+            ValidationLayers = getValidationLayers(*Device.m_Instance);
+            deviceCreateInfo.enabledLayerCount = static_cast<std::uint32_t>(ValidationLayers.size());
+            deviceCreateInfo.ppEnabledLayerNames = ValidationLayers.data();
         }
 
-        if( auto VKErr = vkCreateDevice( Device.m_VKPhysicalDevice
-                                    , &deviceCreateInfo
-                                    , Device.m_Instance->m_pVKAllocator
-                                    , &Device.m_VKDevice ); VKErr )
+        if (auto VKErr = vkCreateDevice(Device.m_VKPhysicalDevice
+            , &deviceCreateInfo
+            , Device.m_Instance->m_pVKAllocator
+            , &Device.m_VKDevice); VKErr)
         {
             Device.m_Instance->ReportError(VKErr, "Fail to create the Vulkan Graphical Device");
-            return VGPU_ERROR(xgpu::device::error::FAILURE, "Fail to create the Vulkan Graphical Device" );
+            return VGPU_ERROR(xgpu::device::error::FAILURE, "Fail to create the Vulkan Graphical Device");
         }
 
         return nullptr;
@@ -102,30 +102,30 @@ namespace xgpu::vulkan
     //----------------------------------------------------------------------------------------------------------
 
     xgpu::device::error* device::Initialize
-    (   std::shared_ptr<xgpu::vulkan::instance>&    Instance
-    ,   const xgpu::device::setup&                  Setup
-    ,   std::uint32_t                               MainQueueIndex
-    ,   VkPhysicalDevice                            PhysicalDevice
-    ,   std::vector<VkQueueFamilyProperties>        Properties ) noexcept
+    (std::shared_ptr<xgpu::vulkan::instance>& Instance
+        , const xgpu::device::setup& Setup
+        , std::uint32_t                               MainQueueIndex
+        , VkPhysicalDevice                            PhysicalDevice
+        , std::vector<VkQueueFamilyProperties>        Properties) noexcept
     {
         // Referece back to the instance
-        m_Instance          = Instance;
-        m_VKPhysicalDevice  = PhysicalDevice;
-        m_MainQueueIndex    = MainQueueIndex;
+        m_Instance = Instance;
+        m_VKPhysicalDevice = PhysicalDevice;
+        m_MainQueueIndex = MainQueueIndex;
 
         //
         // Vulkan device
         //
-        switch( Setup.m_Type )
+        switch (Setup.m_Type)
         {
-            case xgpu::device::type::COMPUTE:
-            case xgpu::device::type::COPY:
-                m_Instance->ReportError("Fail to create the Vulkan Device (This device is unsupported right now)");
-                return VGPU_ERROR(xgpu::device::error::FAILURE, "Fail to create the Vulkan Device (This device is unsupported right now)");
-            case xgpu::device::type::RENDER_AND_SWAP:
-            case xgpu::device::type::RENDER_ONLY:
-                if( auto VErr = CreateGraphicsDevice(*this, m_Instance->m_bValidation, Properties ); VErr )
-                    return VErr;
+        case xgpu::device::type::COMPUTE:
+        case xgpu::device::type::COPY:
+            m_Instance->ReportError("Fail to create the Vulkan Device (This device is unsupported right now)");
+            return VGPU_ERROR(xgpu::device::error::FAILURE, "Fail to create the Vulkan Device (This device is unsupported right now)");
+        case xgpu::device::type::RENDER_AND_SWAP:
+        case xgpu::device::type::RENDER_ONLY:
+            if (auto VErr = CreateGraphicsDevice(*this, m_Instance->m_bValidation, Properties); VErr)
+                return VErr;
             break;
         }
 
@@ -134,16 +134,16 @@ namespace xgpu::vulkan
         //
         {
             std::scoped_lock Lks(m_VKMainQueue, m_VKTransferQueue);
-            vkGetDeviceQueue(m_VKDevice, MainQueueIndex,       0, &m_VKMainQueue.get());
+            vkGetDeviceQueue(m_VKDevice, MainQueueIndex, 0, &m_VKMainQueue.get());
             vkGetDeviceQueue(m_VKDevice, m_TransferQueueIndex, 0, &m_VKTransferQueue.get());
         }
-        
+
         //
         // Gather physical device memory properties
         //
         vkGetPhysicalDeviceMemoryProperties(m_VKPhysicalDevice, &m_VKDeviceMemoryProperties);
         vkGetPhysicalDeviceProperties(m_VKPhysicalDevice, &m_VKPhysicalDeviceProperties);
-        
+
         //
         // Create the Pipeline Cache
         //
@@ -151,13 +151,13 @@ namespace xgpu::vulkan
         {
             .sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO
         };
-        if( auto VKErr = vkCreatePipelineCache( m_VKDevice
-                                                , &pipelineCacheCreateInfo
-                                                , m_Instance->m_pVKAllocator
-                                                , &m_VKPipelineCache 
-                                                ); VKErr )
+        if (auto VKErr = vkCreatePipelineCache(m_VKDevice
+            , &pipelineCacheCreateInfo
+            , m_Instance->m_pVKAllocator
+            , &m_VKPipelineCache
+        ); VKErr)
         {
-            m_Instance->ReportError( VKErr, "Fail to Create the pipeline cache" );
+            m_Instance->ReportError(VKErr, "Fail to Create the pipeline cache");
             return VGPU_ERROR(xgpu::device::error::FAILURE, "Fail to Create the pipeline cache");
         }
 
@@ -169,9 +169,9 @@ namespace xgpu::vulkan
         //
         {
             constexpr auto max_descriptors_per_pool_v = 1000u;
-            
+
             const auto PoolSizes = std::array
-            {   VkDescriptorPoolSize{ VK_DESCRIPTOR_TYPE_SAMPLER,                   max_descriptors_per_pool_v }
+            { VkDescriptorPoolSize{ VK_DESCRIPTOR_TYPE_SAMPLER,                   max_descriptors_per_pool_v }
             ,   VkDescriptorPoolSize{ VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,    max_descriptors_per_pool_v }
             ,   VkDescriptorPoolSize{ VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,             max_descriptors_per_pool_v }
             ,   VkDescriptorPoolSize{ VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,             max_descriptors_per_pool_v }
@@ -184,16 +184,16 @@ namespace xgpu::vulkan
             ,   VkDescriptorPoolSize{ VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT,          max_descriptors_per_pool_v }
             };
 
-            VkDescriptorPoolCreateInfo PoolCreateInfo = 
-            { .sType            = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO
-            , .flags            = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT
-            , .maxSets          = static_cast<uint32_t>(max_descriptors_per_pool_v)
-            , .poolSizeCount    = static_cast<uint32_t>(PoolSizes.size())
-            , .pPoolSizes       = PoolSizes.data()
+            VkDescriptorPoolCreateInfo PoolCreateInfo =
+            { .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO
+            , .flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT
+            , .maxSets = static_cast<uint32_t>(max_descriptors_per_pool_v)
+            , .poolSizeCount = static_cast<uint32_t>(PoolSizes.size())
+            , .pPoolSizes = PoolSizes.data()
             };
 
             {
-                std::lock_guard Lk( m_LockedVKDescriptorPool );
+                std::lock_guard Lk(m_LockedVKDescriptorPool);
                 if (auto VKErr = vkCreateDescriptorPool(m_VKDevice, &PoolCreateInfo, m_Instance->m_pVKAllocator, &m_LockedVKDescriptorPool.get()); VKErr)
                 {
                     m_Instance->ReportError(VKErr, "Fail to create a Descriptor Pool");
@@ -208,7 +208,7 @@ namespace xgpu::vulkan
 
     //----------------------------------------------------------------------------------------------------------
 
-    void device::getInstance( xgpu::instance& Instance ) const noexcept
+    void device::getInstance(xgpu::instance& Instance) const noexcept
     {
         Instance.m_Private = m_Instance;
     }
@@ -216,16 +216,16 @@ namespace xgpu::vulkan
     //----------------------------------------------------------------------------------------------------------
 
     bool device::getMemoryType
-    ( std::uint32_t     TypeBits
-    , const VkFlags     Properties
-    , std::uint32_t&    TypeIndex
+    (std::uint32_t     TypeBits
+        , const VkFlags     Properties
+        , std::uint32_t& TypeIndex
     ) const noexcept
     {
-        for( std::uint32_t i = 0; i < 32; i++ )
+        for (std::uint32_t i = 0; i < 32; i++)
         {
-            if( TypeBits & 1 )
+            if (TypeBits & 1)
             {
-                if( (m_VKDeviceMemoryProperties.memoryTypes[i].propertyFlags & Properties) == Properties )
+                if ((m_VKDeviceMemoryProperties.memoryTypes[i].propertyFlags & Properties) == Properties)
                 {
                     TypeIndex = i;
                     return true;
@@ -234,13 +234,13 @@ namespace xgpu::vulkan
             TypeBits >>= 1;
         }
 
-        m_Instance->ReportWarning( "Fail to find memory flags" );
+        m_Instance->ReportWarning("Fail to find memory flags");
         return false;
     }
 
     //----------------------------------------------------------------------------------------------------------
 
-    void device::FlushCommands( void )
+    void device::FlushCommands(void)
     {
 
     }
@@ -248,16 +248,16 @@ namespace xgpu::vulkan
     //------------------------------------------------------------------------------------------------------------------
 
     xgpu::device::error* device::Create
-    ( xgpu::window&                     Window
-    , const xgpu::window::setup&        Setup
-    , std::shared_ptr<device_handle>&   SharedDevice
+    (xgpu::window& Window
+        , const xgpu::window::setup& Setup
+        , std::shared_ptr<device_handle>& SharedDevice
     ) noexcept
     {
         auto NewWindow = std::make_unique< xgpu::vulkan::window >();
-        if( auto Err = NewWindow->Initialize
-        ( std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice)
-        , Setup 
-        ); Err ) return Err;
+        if (auto Err = NewWindow->Initialize
+        (std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice)
+            , Setup
+        ); Err) return Err;
 
         Window.m_Private = std::move(NewWindow);
 
@@ -266,16 +266,16 @@ namespace xgpu::vulkan
 
     //----------------------------------------------------------------------------------------------------------
 
-    xgpu::device::error* device::Create              
-    ( xgpu::renderpass&                         Renderpass
-    , const xgpu::renderpass::setup&            Setup
-    , std::shared_ptr<device_handle>&           SharedDevice
+    xgpu::device::error* device::Create
+    (xgpu::renderpass& Renderpass
+        , const xgpu::renderpass::setup& Setup
+        , std::shared_ptr<device_handle>& SharedDevice
     ) noexcept
     {
         auto NewRenderpass = std::make_unique< xgpu::vulkan::renderpass >();
         if (auto Err = NewRenderpass->Initialize
-        ( std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice)
-        , Setup
+        (std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice)
+            , Setup
         ); Err) return Err;
 
         Renderpass.m_Private = std::move(NewRenderpass);
@@ -286,32 +286,32 @@ namespace xgpu::vulkan
     //----------------------------------------------------------------------------------------------------------
 
     xgpu::device::error* device::Create
-    ( xgpu::pipeline&                   Pipeline
-    , const xgpu::pipeline::setup&      Setup
-    , std::shared_ptr<device_handle>&   SharedDevice
+    (xgpu::pipeline& Pipeline
+        , const xgpu::pipeline::setup& Setup
+        , std::shared_ptr<device_handle>& SharedDevice
     ) noexcept
     {
         auto Pl = std::make_shared<xgpu::vulkan::pipeline>();
-        if ( auto Err = Pl->Initialize
-        ( std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice)
-        , Setup 
-        ); Err ) return Err;
+        if (auto Err = Pl->Initialize
+        (std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice)
+            , Setup
+        ); Err) return Err;
         Pipeline.m_Private = std::move(Pl);
         return nullptr;
     }
 
     //----------------------------------------------------------------------------------------------------------
     xgpu::device::error* device::Create
-    ( xgpu::buffer&                   Buffer
-    , const xgpu::buffer::setup&      Setup
-    , std::shared_ptr<device_handle>& SharedDevice
+    (xgpu::buffer& Buffer
+        , const xgpu::buffer::setup& Setup
+        , std::shared_ptr<device_handle>& SharedDevice
     ) noexcept
     {
         auto B = std::make_unique<xgpu::vulkan::buffer>();
-        if( auto Err = B->Initialize
-        ( std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice)
-        , Setup
-        ); Err ) return Err;
+        if (auto Err = B->Initialize
+        (std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice)
+            , Setup
+        ); Err) return Err;
         Buffer.m_Private = std::move(B);
         return nullptr;
     }
@@ -319,15 +319,15 @@ namespace xgpu::vulkan
     //----------------------------------------------------------------------------------------------------------
 
     xgpu::device::error* device::Create
-    ( xgpu::pipeline_instance&              PipelineInstance
-    , const xgpu::pipeline_instance::setup& Setup
-    , std::shared_ptr<device_handle>&       SharedDevice
+    (xgpu::pipeline_instance& PipelineInstance
+        , const xgpu::pipeline_instance::setup& Setup
+        , std::shared_ptr<device_handle>& SharedDevice
     ) noexcept
     {
         auto PI = std::make_unique<xgpu::vulkan::pipeline_instance>();
-        if( auto Err = PI->Initialize
-        ( std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice)
-        , Setup 
+        if (auto Err = PI->Initialize
+        (std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice)
+            , Setup
         ); Err) return Err;
         PipelineInstance.m_Private = std::move(PI);
         return nullptr;
@@ -336,13 +336,13 @@ namespace xgpu::vulkan
     //----------------------------------------------------------------------------------------------------------
 
     xgpu::device::error* device::Create
-    ( xgpu::shader&                     Shader
-    , const xgpu::shader::setup&        Setup 
-    , std::shared_ptr<device_handle>&   SharedDevice
+    (xgpu::shader& Shader
+        , const xgpu::shader::setup& Setup
+        , std::shared_ptr<device_handle>& SharedDevice
     ) noexcept
     {
         auto VulkanShader = std::make_shared<xgpu::vulkan::shader>();
-        if( auto Err = VulkanShader->Initialize( std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice), Setup ); Err ) 
+        if (auto Err = VulkanShader->Initialize(std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice), Setup); Err)
             return Err;
         Shader.m_Private = VulkanShader;
         return nullptr;
@@ -351,13 +351,13 @@ namespace xgpu::vulkan
     //----------------------------------------------------------------------------------------------------------
 
     xgpu::device::error* device::Create
-    ( xgpu::vertex_descriptor&              VDescriptor
-    , const xgpu::vertex_descriptor::setup& Setup
-    , std::shared_ptr<device_handle>&       SharedDevice
+    (xgpu::vertex_descriptor& VDescriptor
+        , const xgpu::vertex_descriptor::setup& Setup
+        , std::shared_ptr<device_handle>& SharedDevice
     ) noexcept
     {
         auto VDesc = std::make_shared<xgpu::vulkan::vertex_descriptor>();
-        if( auto Err = VDesc->Initialize( Setup ); Err ) 
+        if (auto Err = VDesc->Initialize(Setup); Err)
             return Err;
         VDescriptor.m_Private = VDesc;
         return nullptr;
@@ -366,13 +366,13 @@ namespace xgpu::vulkan
     //----------------------------------------------------------------------------------------------------------
 
     xgpu::device::error* device::Create
-    ( xgpu::texture&                    Texture
-    , const xgpu::texture::setup&       Setup
-    , std::shared_ptr<device_handle>&   SharedDevice
+    (xgpu::texture& Texture
+        , const xgpu::texture::setup& Setup
+        , std::shared_ptr<device_handle>& SharedDevice
     ) noexcept
     {
         auto I = std::make_shared<xgpu::vulkan::texture>();
-        if( auto Err = I->Initialize( std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice), Setup ); Err ) 
+        if (auto Err = I->Initialize(std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice), Setup); Err)
             return Err;
         Texture.m_Private = I;
         return nullptr;
@@ -381,6 +381,22 @@ namespace xgpu::vulkan
     //----------------------------------------------------------------------------------------------------------
     void device::PageFlipNotification(void) noexcept
     {
+        DeathMarch();
+
+    }
+
+    //----------------------------------------------------------------------------------------------------------
+
+    void device::Destroy(xgpu::texture&& Texture)                     noexcept { m_DeathMarchList[m_FrameIndex % m_DeathMarchList.size()].m_Texture.push_back(std::move(Texture)); }
+    void device::Destroy(xgpu::pipeline_instance&& PipelineInstance)  noexcept { m_DeathMarchList[m_FrameIndex % m_DeathMarchList.size()].m_PipelineInstance.push_back(std::move(PipelineInstance)); }
+    void device::Destroy(xgpu::pipeline&& Pipeline)                   noexcept { m_DeathMarchList[m_FrameIndex % m_DeathMarchList.size()].m_Pipeline.push_back(std::move(Pipeline)); }
+    void device::Destroy(xgpu::buffer&& Buffer)                       noexcept { m_DeathMarchList[m_FrameIndex % m_DeathMarchList.size()].m_Buffer.push_back(std::move(Buffer)); }
+
+    //----------------------------------------------------------------------------------------------------------
+
+    void device::DeathMarch(void) noexcept
+    {
+
         m_FrameIndex++;
 
         auto& DeathMarch = m_DeathMarchList[m_FrameIndex % m_DeathMarchList.size()];
@@ -392,15 +408,15 @@ namespace xgpu::vulkan
             DeathMarch.m_Texture.clear();
         }
 
-        if (false == DeathMarch.m_PipelineInstance.empty() )
+        if (false == DeathMarch.m_PipelineInstance.empty())
         {
             for (auto& E : DeathMarch.m_PipelineInstance)
             {
-                if ( E.m_Private.use_count() == 1 )
+                if (E.m_Private.use_count() == 1)
                 {
                     if (auto It = m_PipeLineInstanceMap.find(reinterpret_cast<std::uint64_t>(E.m_Private.get())); It != m_PipeLineInstanceMap.end())
                     {
-                        m_PipeLineInstanceMap.erase( It );
+                        m_PipeLineInstanceMap.erase(It);
                     }
                 }
                 E.m_Private.reset();
@@ -408,11 +424,11 @@ namespace xgpu::vulkan
             DeathMarch.m_PipelineInstance.clear();
         }
 
-        if ( false == DeathMarch.m_Pipeline.empty())
+        if (false == DeathMarch.m_Pipeline.empty())
         {
             for (auto& E : DeathMarch.m_Pipeline)
             {
-                if( E.m_Private.use_count() == 1 )
+                if (E.m_Private.use_count() == 1)
                 {
                     for (auto it = m_PipeLineMap.begin(); it != m_PipeLineMap.end(); )
                     {
@@ -431,13 +447,16 @@ namespace xgpu::vulkan
             DeathMarch.m_Pipeline.clear();
         }
 
+        if (false == DeathMarch.m_Buffer.empty())
+        {
+            DeathMarch.m_Buffer.clear();
+        }
     }
 
-    //----------------------------------------------------------------------------------------------------------
-
-    void device::Destroy(xgpu::texture&& Texture)                     noexcept { m_DeathMarchList[m_FrameIndex % m_DeathMarchList.size()].m_Texture.push_back(std::move(Texture)); }
-    void device::Destroy(xgpu::pipeline_instance&& PipelineInstance)  noexcept { m_DeathMarchList[m_FrameIndex % m_DeathMarchList.size()].m_PipelineInstance.push_back(std::move(PipelineInstance)); }
-    void device::Destroy(xgpu::pipeline&& Pipeline)                   noexcept { m_DeathMarchList[m_FrameIndex % m_DeathMarchList.size()].m_Pipeline.push_back(std::move(Pipeline)); }
+    void device::Shutdown(void) noexcept
+    {
+        DeathMarch();
+    }
 }
 
 

--- a/Src/Details/Vulkan/xgpu_vulkan_device.cpp
+++ b/Src/Details/Vulkan/xgpu_vulkan_device.cpp
@@ -1,31 +1,30 @@
-
 namespace xgpu::vulkan
 {
     //----------------------------------------------------------------------------------------------------------
 
     xgpu::device::error* CreateGraphicsDevice
-    (device& Device
-        , const bool                                    enableValidation
-        , const std::vector<VkQueueFamilyProperties>& DeviceProperties
+    ( device&                                       Device
+    , const bool                                    enableValidation
+    , const std::vector<VkQueueFamilyProperties>&   DeviceProperties 
     ) noexcept
     {
         //
         // Lets find a transfer queue... because we are going to let assets transfer at lighting speed
         // (So async transfers)
-        for (auto i = 0u; i < DeviceProperties.size(); ++i)
+        for( auto i=0u; i<DeviceProperties.size(); ++i )
         {
             // We want to find a queue that is not compute, or graphics
             // we just need to transfer
-            if ((DeviceProperties[i].queueFlags & VK_QUEUE_TRANSFER_BIT)
-                && (Device.m_MainQueueIndex != i)
-                )
+            if(    (DeviceProperties[i].queueFlags & VK_QUEUE_TRANSFER_BIT) 
+                && ( Device.m_MainQueueIndex != i )
+              )
             {
                 Device.m_TransferQueueIndex = i;
                 break;
             }
         }
 
-        if (Device.m_TransferQueueIndex == 0xffffffff)
+        if( Device.m_TransferQueueIndex == 0xffffffff )
         {
             Device.m_Instance->ReportError("Unable to find a transfer only queue");
             return VGPU_ERROR(xgpu::device::error::FAILURE, "Unable to find a transfer only queue");
@@ -34,21 +33,21 @@ namespace xgpu::vulkan
         //
         // Prepare our queues
         //
-        static const std::array     queuePriorities = { 0.0f };
+        static const std::array     queuePriorities    = {    0.0f };
         auto queueCreateInfo = std::array
-        { VkDeviceQueueCreateInfo
+        {   VkDeviceQueueCreateInfo 
             {
-                .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO
-            ,   .queueFamilyIndex = Device.m_MainQueueIndex
-            ,   .queueCount = static_cast<std::uint32_t>(queuePriorities.size())
-            ,   .pQueuePriorities = queuePriorities.data()
+                .sType              = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO
+            ,   .queueFamilyIndex   = Device.m_MainQueueIndex
+            ,   .queueCount         = static_cast<std::uint32_t>(queuePriorities.size())
+            ,   .pQueuePriorities   = queuePriorities.data()
             }
         ,   VkDeviceQueueCreateInfo
             {
-                .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO
-            ,   .queueFamilyIndex = Device.m_TransferQueueIndex
-            ,   .queueCount = static_cast<std::uint32_t>(queuePriorities.size())
-            ,   .pQueuePriorities = queuePriorities.data()
+                .sType              = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO
+            ,   .queueFamilyIndex   = Device.m_TransferQueueIndex
+            ,   .queueCount         = static_cast<std::uint32_t>(queuePriorities.size())
+            ,   .pQueuePriorities   = queuePriorities.data()
             }
         };
 
@@ -56,44 +55,44 @@ namespace xgpu::vulkan
         // Create device now
         //
         VkPhysicalDeviceFeatures Features{};
-        vkGetPhysicalDeviceFeatures(Device.m_VKPhysicalDevice, &Features);
+        vkGetPhysicalDeviceFeatures( Device.m_VKPhysicalDevice, &Features );
         Features.shaderClipDistance = true;
         Features.shaderCullDistance = true;
-        Features.samplerAnisotropy = true;
+        Features.samplerAnisotropy  = true;
 
-        static constexpr auto       enabledExtensions = std::array
-        {
+        static constexpr auto       enabledExtensions   = std::array
+        { 
             VK_KHR_SWAPCHAIN_EXTENSION_NAME
-            //        ,   VK_NV_GLSL_SHADER_EXTENSION_NAME  // nVidia useful extension to be able to load GLSL shaders
+//        ,   VK_NV_GLSL_SHADER_EXTENSION_NAME  // nVidia useful extension to be able to load GLSL shaders
         };
         VkDeviceCreateInfo          deviceCreateInfo
         {
-            .sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO
-        ,   .pNext = nullptr
-        ,   .queueCreateInfoCount = static_cast<uint32_t>(queueCreateInfo.size())
-        ,   .pQueueCreateInfos = queueCreateInfo.data()
-        ,   .enabledLayerCount = 0
-        ,   .ppEnabledLayerNames = nullptr
-        ,   .enabledExtensionCount = static_cast<uint32_t>(enabledExtensions.size())
-        ,   .ppEnabledExtensionNames = enabledExtensions.data()
-        ,   .pEnabledFeatures = &Features
+            .sType                      = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO
+        ,   .pNext                      = nullptr
+        ,   .queueCreateInfoCount       = static_cast<uint32_t>(queueCreateInfo.size())
+        ,   .pQueueCreateInfos          = queueCreateInfo.data()
+        ,   .enabledLayerCount          = 0
+        ,   .ppEnabledLayerNames        = nullptr
+        ,   .enabledExtensionCount      = static_cast<uint32_t>(enabledExtensions.size())
+        ,   .ppEnabledExtensionNames    = enabledExtensions.data()
+        ,   .pEnabledFeatures           = &Features
         };
 
         std::vector<const char*>    ValidationLayers{};
-        if (Device.m_Instance->m_bValidation)
+        if( Device.m_Instance->m_bValidation )
         {
-            ValidationLayers = getValidationLayers(*Device.m_Instance);
-            deviceCreateInfo.enabledLayerCount = static_cast<std::uint32_t>(ValidationLayers.size());
-            deviceCreateInfo.ppEnabledLayerNames = ValidationLayers.data();
+            ValidationLayers = getValidationLayers( *Device.m_Instance );
+            deviceCreateInfo.enabledLayerCount          = static_cast<std::uint32_t>(ValidationLayers.size());
+            deviceCreateInfo.ppEnabledLayerNames        = ValidationLayers.data();
         }
 
-        if (auto VKErr = vkCreateDevice(Device.m_VKPhysicalDevice
-            , &deviceCreateInfo
-            , Device.m_Instance->m_pVKAllocator
-            , &Device.m_VKDevice); VKErr)
+        if( auto VKErr = vkCreateDevice( Device.m_VKPhysicalDevice
+                                    , &deviceCreateInfo
+                                    , Device.m_Instance->m_pVKAllocator
+                                    , &Device.m_VKDevice ); VKErr )
         {
             Device.m_Instance->ReportError(VKErr, "Fail to create the Vulkan Graphical Device");
-            return VGPU_ERROR(xgpu::device::error::FAILURE, "Fail to create the Vulkan Graphical Device");
+            return VGPU_ERROR(xgpu::device::error::FAILURE, "Fail to create the Vulkan Graphical Device" );
         }
 
         return nullptr;
@@ -102,30 +101,30 @@ namespace xgpu::vulkan
     //----------------------------------------------------------------------------------------------------------
 
     xgpu::device::error* device::Initialize
-    (std::shared_ptr<xgpu::vulkan::instance>& Instance
-        , const xgpu::device::setup& Setup
-        , std::uint32_t                               MainQueueIndex
-        , VkPhysicalDevice                            PhysicalDevice
-        , std::vector<VkQueueFamilyProperties>        Properties) noexcept
+    (   std::shared_ptr<xgpu::vulkan::instance>&    Instance
+    ,   const xgpu::device::setup&                  Setup
+    ,   std::uint32_t                               MainQueueIndex
+    ,   VkPhysicalDevice                            PhysicalDevice
+    ,   std::vector<VkQueueFamilyProperties>        Properties ) noexcept
     {
         // Referece back to the instance
-        m_Instance = Instance;
-        m_VKPhysicalDevice = PhysicalDevice;
-        m_MainQueueIndex = MainQueueIndex;
+        m_Instance          = Instance;
+        m_VKPhysicalDevice  = PhysicalDevice;
+        m_MainQueueIndex    = MainQueueIndex;
 
         //
         // Vulkan device
         //
-        switch (Setup.m_Type)
+        switch( Setup.m_Type )
         {
-        case xgpu::device::type::COMPUTE:
-        case xgpu::device::type::COPY:
-            m_Instance->ReportError("Fail to create the Vulkan Device (This device is unsupported right now)");
-            return VGPU_ERROR(xgpu::device::error::FAILURE, "Fail to create the Vulkan Device (This device is unsupported right now)");
-        case xgpu::device::type::RENDER_AND_SWAP:
-        case xgpu::device::type::RENDER_ONLY:
-            if (auto VErr = CreateGraphicsDevice(*this, m_Instance->m_bValidation, Properties); VErr)
-                return VErr;
+            case xgpu::device::type::COMPUTE:
+            case xgpu::device::type::COPY:
+                m_Instance->ReportError("Fail to create the Vulkan Device (This device is unsupported right now)");
+                return VGPU_ERROR(xgpu::device::error::FAILURE, "Fail to create the Vulkan Device (This device is unsupported right now)");
+            case xgpu::device::type::RENDER_AND_SWAP:
+            case xgpu::device::type::RENDER_ONLY:
+                if( auto VErr = CreateGraphicsDevice(*this, m_Instance->m_bValidation, Properties ); VErr )
+                    return VErr;
             break;
         }
 
@@ -134,16 +133,16 @@ namespace xgpu::vulkan
         //
         {
             std::scoped_lock Lks(m_VKMainQueue, m_VKTransferQueue);
-            vkGetDeviceQueue(m_VKDevice, MainQueueIndex, 0, &m_VKMainQueue.get());
+            vkGetDeviceQueue(m_VKDevice, MainQueueIndex,       0, &m_VKMainQueue.get());
             vkGetDeviceQueue(m_VKDevice, m_TransferQueueIndex, 0, &m_VKTransferQueue.get());
         }
-
+        
         //
         // Gather physical device memory properties
         //
         vkGetPhysicalDeviceMemoryProperties(m_VKPhysicalDevice, &m_VKDeviceMemoryProperties);
         vkGetPhysicalDeviceProperties(m_VKPhysicalDevice, &m_VKPhysicalDeviceProperties);
-
+        
         //
         // Create the Pipeline Cache
         //
@@ -151,13 +150,13 @@ namespace xgpu::vulkan
         {
             .sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO
         };
-        if (auto VKErr = vkCreatePipelineCache(m_VKDevice
-            , &pipelineCacheCreateInfo
-            , m_Instance->m_pVKAllocator
-            , &m_VKPipelineCache
-        ); VKErr)
+        if( auto VKErr = vkCreatePipelineCache( m_VKDevice
+                                                , &pipelineCacheCreateInfo
+                                                , m_Instance->m_pVKAllocator
+                                                , &m_VKPipelineCache 
+                                                ); VKErr )
         {
-            m_Instance->ReportError(VKErr, "Fail to Create the pipeline cache");
+            m_Instance->ReportError( VKErr, "Fail to Create the pipeline cache" );
             return VGPU_ERROR(xgpu::device::error::FAILURE, "Fail to Create the pipeline cache");
         }
 
@@ -169,9 +168,9 @@ namespace xgpu::vulkan
         //
         {
             constexpr auto max_descriptors_per_pool_v = 1000u;
-
+            
             const auto PoolSizes = std::array
-            { VkDescriptorPoolSize{ VK_DESCRIPTOR_TYPE_SAMPLER,                   max_descriptors_per_pool_v }
+            {   VkDescriptorPoolSize{ VK_DESCRIPTOR_TYPE_SAMPLER,                   max_descriptors_per_pool_v }
             ,   VkDescriptorPoolSize{ VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,    max_descriptors_per_pool_v }
             ,   VkDescriptorPoolSize{ VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,             max_descriptors_per_pool_v }
             ,   VkDescriptorPoolSize{ VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,             max_descriptors_per_pool_v }
@@ -184,16 +183,16 @@ namespace xgpu::vulkan
             ,   VkDescriptorPoolSize{ VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT,          max_descriptors_per_pool_v }
             };
 
-            VkDescriptorPoolCreateInfo PoolCreateInfo =
-            { .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO
-            , .flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT
-            , .maxSets = static_cast<uint32_t>(max_descriptors_per_pool_v)
-            , .poolSizeCount = static_cast<uint32_t>(PoolSizes.size())
-            , .pPoolSizes = PoolSizes.data()
+            VkDescriptorPoolCreateInfo PoolCreateInfo = 
+            { .sType            = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO
+            , .flags            = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT
+            , .maxSets          = static_cast<uint32_t>(max_descriptors_per_pool_v)
+            , .poolSizeCount    = static_cast<uint32_t>(PoolSizes.size())
+            , .pPoolSizes       = PoolSizes.data()
             };
 
             {
-                std::lock_guard Lk(m_LockedVKDescriptorPool);
+                std::lock_guard Lk( m_LockedVKDescriptorPool );
                 if (auto VKErr = vkCreateDescriptorPool(m_VKDevice, &PoolCreateInfo, m_Instance->m_pVKAllocator, &m_LockedVKDescriptorPool.get()); VKErr)
                 {
                     m_Instance->ReportError(VKErr, "Fail to create a Descriptor Pool");
@@ -208,7 +207,7 @@ namespace xgpu::vulkan
 
     //----------------------------------------------------------------------------------------------------------
 
-    void device::getInstance(xgpu::instance& Instance) const noexcept
+    void device::getInstance( xgpu::instance& Instance ) const noexcept
     {
         Instance.m_Private = m_Instance;
     }
@@ -216,16 +215,16 @@ namespace xgpu::vulkan
     //----------------------------------------------------------------------------------------------------------
 
     bool device::getMemoryType
-    (std::uint32_t     TypeBits
-        , const VkFlags     Properties
-        , std::uint32_t& TypeIndex
+    ( std::uint32_t     TypeBits
+    , const VkFlags     Properties
+    , std::uint32_t&    TypeIndex
     ) const noexcept
     {
-        for (std::uint32_t i = 0; i < 32; i++)
+        for( std::uint32_t i = 0; i < 32; i++ )
         {
-            if (TypeBits & 1)
+            if( TypeBits & 1 )
             {
-                if ((m_VKDeviceMemoryProperties.memoryTypes[i].propertyFlags & Properties) == Properties)
+                if( (m_VKDeviceMemoryProperties.memoryTypes[i].propertyFlags & Properties) == Properties )
                 {
                     TypeIndex = i;
                     return true;
@@ -234,13 +233,13 @@ namespace xgpu::vulkan
             TypeBits >>= 1;
         }
 
-        m_Instance->ReportWarning("Fail to find memory flags");
+        m_Instance->ReportWarning( "Fail to find memory flags" );
         return false;
     }
 
     //----------------------------------------------------------------------------------------------------------
 
-    void device::FlushCommands(void)
+    void device::FlushCommands( void )
     {
 
     }
@@ -248,16 +247,16 @@ namespace xgpu::vulkan
     //------------------------------------------------------------------------------------------------------------------
 
     xgpu::device::error* device::Create
-    (xgpu::window& Window
-        , const xgpu::window::setup& Setup
-        , std::shared_ptr<device_handle>& SharedDevice
+    ( xgpu::window&                     Window
+    , const xgpu::window::setup&        Setup
+    , std::shared_ptr<device_handle>&   SharedDevice
     ) noexcept
     {
         auto NewWindow = std::make_unique< xgpu::vulkan::window >();
-        if (auto Err = NewWindow->Initialize
-        (std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice)
-            , Setup
-        ); Err) return Err;
+        if( auto Err = NewWindow->Initialize
+        ( std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice)
+        , Setup 
+        ); Err ) return Err;
 
         Window.m_Private = std::move(NewWindow);
 
@@ -266,16 +265,16 @@ namespace xgpu::vulkan
 
     //----------------------------------------------------------------------------------------------------------
 
-    xgpu::device::error* device::Create
-    (xgpu::renderpass& Renderpass
-        , const xgpu::renderpass::setup& Setup
-        , std::shared_ptr<device_handle>& SharedDevice
+    xgpu::device::error* device::Create              
+    ( xgpu::renderpass&                         Renderpass
+    , const xgpu::renderpass::setup&            Setup
+    , std::shared_ptr<device_handle>&           SharedDevice
     ) noexcept
     {
         auto NewRenderpass = std::make_unique< xgpu::vulkan::renderpass >();
         if (auto Err = NewRenderpass->Initialize
-        (std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice)
-            , Setup
+        ( std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice)
+        , Setup
         ); Err) return Err;
 
         Renderpass.m_Private = std::move(NewRenderpass);
@@ -286,32 +285,32 @@ namespace xgpu::vulkan
     //----------------------------------------------------------------------------------------------------------
 
     xgpu::device::error* device::Create
-    (xgpu::pipeline& Pipeline
-        , const xgpu::pipeline::setup& Setup
-        , std::shared_ptr<device_handle>& SharedDevice
+    ( xgpu::pipeline&                   Pipeline
+    , const xgpu::pipeline::setup&      Setup
+    , std::shared_ptr<device_handle>&   SharedDevice
     ) noexcept
     {
         auto Pl = std::make_shared<xgpu::vulkan::pipeline>();
-        if (auto Err = Pl->Initialize
-        (std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice)
-            , Setup
-        ); Err) return Err;
+        if ( auto Err = Pl->Initialize
+        ( std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice)
+        , Setup 
+        ); Err ) return Err;
         Pipeline.m_Private = std::move(Pl);
         return nullptr;
     }
 
     //----------------------------------------------------------------------------------------------------------
     xgpu::device::error* device::Create
-    (xgpu::buffer& Buffer
-        , const xgpu::buffer::setup& Setup
-        , std::shared_ptr<device_handle>& SharedDevice
+    ( xgpu::buffer&                   Buffer
+    , const xgpu::buffer::setup&      Setup
+    , std::shared_ptr<device_handle>& SharedDevice
     ) noexcept
     {
         auto B = std::make_unique<xgpu::vulkan::buffer>();
-        if (auto Err = B->Initialize
-        (std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice)
-            , Setup
-        ); Err) return Err;
+        if( auto Err = B->Initialize
+        ( std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice)
+        , Setup
+        ); Err ) return Err;
         Buffer.m_Private = std::move(B);
         return nullptr;
     }
@@ -319,15 +318,15 @@ namespace xgpu::vulkan
     //----------------------------------------------------------------------------------------------------------
 
     xgpu::device::error* device::Create
-    (xgpu::pipeline_instance& PipelineInstance
-        , const xgpu::pipeline_instance::setup& Setup
-        , std::shared_ptr<device_handle>& SharedDevice
+    ( xgpu::pipeline_instance&              PipelineInstance
+    , const xgpu::pipeline_instance::setup& Setup
+    , std::shared_ptr<device_handle>&       SharedDevice
     ) noexcept
     {
         auto PI = std::make_unique<xgpu::vulkan::pipeline_instance>();
-        if (auto Err = PI->Initialize
-        (std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice)
-            , Setup
+        if( auto Err = PI->Initialize
+        ( std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice)
+        , Setup 
         ); Err) return Err;
         PipelineInstance.m_Private = std::move(PI);
         return nullptr;
@@ -336,13 +335,13 @@ namespace xgpu::vulkan
     //----------------------------------------------------------------------------------------------------------
 
     xgpu::device::error* device::Create
-    (xgpu::shader& Shader
-        , const xgpu::shader::setup& Setup
-        , std::shared_ptr<device_handle>& SharedDevice
+    ( xgpu::shader&                     Shader
+    , const xgpu::shader::setup&        Setup 
+    , std::shared_ptr<device_handle>&   SharedDevice
     ) noexcept
     {
         auto VulkanShader = std::make_shared<xgpu::vulkan::shader>();
-        if (auto Err = VulkanShader->Initialize(std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice), Setup); Err)
+        if( auto Err = VulkanShader->Initialize( std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice), Setup ); Err ) 
             return Err;
         Shader.m_Private = VulkanShader;
         return nullptr;
@@ -351,13 +350,13 @@ namespace xgpu::vulkan
     //----------------------------------------------------------------------------------------------------------
 
     xgpu::device::error* device::Create
-    (xgpu::vertex_descriptor& VDescriptor
-        , const xgpu::vertex_descriptor::setup& Setup
-        , std::shared_ptr<device_handle>& SharedDevice
+    ( xgpu::vertex_descriptor&              VDescriptor
+    , const xgpu::vertex_descriptor::setup& Setup
+    , std::shared_ptr<device_handle>&       SharedDevice
     ) noexcept
     {
         auto VDesc = std::make_shared<xgpu::vulkan::vertex_descriptor>();
-        if (auto Err = VDesc->Initialize(Setup); Err)
+        if( auto Err = VDesc->Initialize( Setup ); Err ) 
             return Err;
         VDescriptor.m_Private = VDesc;
         return nullptr;
@@ -366,23 +365,21 @@ namespace xgpu::vulkan
     //----------------------------------------------------------------------------------------------------------
 
     xgpu::device::error* device::Create
-    (xgpu::texture& Texture
-        , const xgpu::texture::setup& Setup
-        , std::shared_ptr<device_handle>& SharedDevice
+    ( xgpu::texture&                    Texture
+    , const xgpu::texture::setup&       Setup
+    , std::shared_ptr<device_handle>&   SharedDevice
     ) noexcept
     {
         auto I = std::make_shared<xgpu::vulkan::texture>();
-        if (auto Err = I->Initialize(std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice), Setup); Err)
+        if( auto Err = I->Initialize( std::reinterpret_pointer_cast<xgpu::vulkan::device>(SharedDevice), Setup ); Err ) 
             return Err;
         Texture.m_Private = I;
         return nullptr;
     }
 
-    //----------------------------------------------------------------------------------------------------------
-    void device::PageFlipNotification(void) noexcept
+    void device::PageFlipNotification(void)
     {
         DeathMarch();
-
     }
 
     //----------------------------------------------------------------------------------------------------------

--- a/Src/Details/Vulkan/xgpu_vulkan_device.cpp
+++ b/Src/Details/Vulkan/xgpu_vulkan_device.cpp
@@ -377,17 +377,29 @@ namespace xgpu::vulkan
         return nullptr;
     }
 
-    void device::PageFlipNotification(void)
+    void device::PageFlipNotification(void) noexcept
     {
         DeathMarch();
     }
 
     //----------------------------------------------------------------------------------------------------------
 
-    void device::Destroy(xgpu::texture&& Texture)                     noexcept { m_DeathMarchList[m_FrameIndex % m_DeathMarchList.size()].m_Texture.push_back(std::move(Texture)); }
-    void device::Destroy(xgpu::pipeline_instance&& PipelineInstance)  noexcept { m_DeathMarchList[m_FrameIndex % m_DeathMarchList.size()].m_PipelineInstance.push_back(std::move(PipelineInstance)); }
-    void device::Destroy(xgpu::pipeline&& Pipeline)                   noexcept { m_DeathMarchList[m_FrameIndex % m_DeathMarchList.size()].m_Pipeline.push_back(std::move(Pipeline)); }
-    void device::Destroy(xgpu::buffer&& Buffer)                       noexcept { m_DeathMarchList[m_FrameIndex % m_DeathMarchList.size()].m_Buffer.push_back(std::move(Buffer)); }
+    void device::Destroy(xgpu::texture&& Texture)                     noexcept 
+    { 
+        m_DeathMarchList[m_FrameIndex % m_DeathMarchList.size()].m_Texture.push_back(std::move(Texture)); 
+    }
+    void device::Destroy(xgpu::pipeline_instance&& PipelineInstance)  noexcept 
+    { 
+        m_DeathMarchList[m_FrameIndex % m_DeathMarchList.size()].m_PipelineInstance.push_back(std::move(PipelineInstance));
+    }
+    void device::Destroy(xgpu::pipeline&& Pipeline)                   noexcept 
+    { 
+        m_DeathMarchList[m_FrameIndex % m_DeathMarchList.size()].m_Pipeline.push_back(std::move(Pipeline)); 
+    }
+    void device::Destroy(xgpu::buffer&& Buffer)                       noexcept 
+    { 
+        m_DeathMarchList[m_FrameIndex % m_DeathMarchList.size()].m_Buffer.push_back(std::move(Buffer)); 
+    }
 
     //----------------------------------------------------------------------------------------------------------
 

--- a/Src/Details/Vulkan/xgpu_vulkan_device.h
+++ b/Src/Details/Vulkan/xgpu_vulkan_device.h
@@ -78,7 +78,6 @@ namespace xgpu::vulkan
             std::vector<xgpu::pipeline_instance>  m_PipelineInstance;
             std::vector<xgpu::pipeline>           m_Pipeline;
             std::vector<xgpu::buffer>             m_Buffer;
-            std::vector<xgpu::window>             m_Frame;
         };
 
         using mati_per_renderpass_map = std::unordered_map<std::uint64_t, pipeline_instance::per_renderpass>;

--- a/Src/Details/Vulkan/xgpu_vulkan_device.h
+++ b/Src/Details/Vulkan/xgpu_vulkan_device.h
@@ -63,10 +63,13 @@ namespace xgpu::vulkan
                                                             ) noexcept override;
 
         void                            PageFlipNotification( void ) noexcept;
+        void                            DeathMarch          ( void ) noexcept;
+        virtual void                    Shutdown            ( void ) noexcept override;
 
         virtual void                    Destroy             ( xgpu::pipeline_instance&& PipelineInstance )  noexcept override;
         virtual void                    Destroy             ( xgpu::pipeline&& Pipeline )                   noexcept override;
         virtual void                    Destroy             ( xgpu::texture&& Texture )                     noexcept override;
+        virtual void                    Destroy             ( xgpu::buffer&& Buffer )                       noexcept override;
 
 
         struct death_march
@@ -74,6 +77,8 @@ namespace xgpu::vulkan
             std::vector<xgpu::texture>            m_Texture;
             std::vector<xgpu::pipeline_instance>  m_PipelineInstance;
             std::vector<xgpu::pipeline>           m_Pipeline;
+            std::vector<xgpu::buffer>             m_Buffer;
+            std::vector<xgpu::window>             m_Frame;
         };
 
         using mati_per_renderpass_map = std::unordered_map<std::uint64_t, pipeline_instance::per_renderpass>;

--- a/Src/Details/Vulkan/xgpu_vulkan_pipeline.cpp
+++ b/Src/Details/Vulkan/xgpu_vulkan_pipeline.cpp
@@ -494,4 +494,11 @@ namespace xgpu::vulkan
 
         return nullptr;
     }
+
+    void pipeline::DeathMarch(xgpu::pipeline&& Pipeline) noexcept
+    {
+        if (!m_Device) return;
+        m_Device->Destroy(std::move(Pipeline));
+        m_Device.reset();
+    }
 }

--- a/Src/Details/Vulkan/xgpu_vulkan_pipeline.h
+++ b/Src/Details/Vulkan/xgpu_vulkan_pipeline.h
@@ -6,6 +6,8 @@ namespace xgpu::vulkan
                                             , const xgpu::pipeline::setup& Setup
                                             ) noexcept;
         ~pipeline(void) override;
+        
+        virtual void              DeathMarch( xgpu::pipeline&& buffer ) noexcept override;
 
         struct per_renderpass
         {

--- a/Src/Details/Vulkan/xgpu_vulkan_pipeline_instance.cpp
+++ b/Src/Details/Vulkan/xgpu_vulkan_pipeline_instance.cpp
@@ -84,4 +84,11 @@ namespace xgpu::vulkan
     }
 
 
+
+    void pipeline_instance::DeathMarch(xgpu::pipeline_instance&& PipelineInstance) noexcept
+    {
+        if (!m_Device) return;
+        m_Device->Destroy(std::move(PipelineInstance));
+        m_Device.reset();
+    }
 }

--- a/Src/Details/Vulkan/xgpu_vulkan_pipeline_instance.h
+++ b/Src/Details/Vulkan/xgpu_vulkan_pipeline_instance.h
@@ -13,6 +13,7 @@ namespace xgpu::vulkan
                                                             , std::size_t               Size
                                                             ) noexcept;
 
+        virtual void            DeathMarch                  ( xgpu::pipeline_instance && buffer) noexcept override;
         struct per_renderpass
         {
             pipeline_instance*              m_pPipelineInstance {};

--- a/Src/Details/Vulkan/xgpu_vulkan_texture.cpp
+++ b/Src/Details/Vulkan/xgpu_vulkan_texture.cpp
@@ -728,5 +728,12 @@ namespace xgpu::vulkan
 
         return nullptr;
     }
+
+    void texture::DeathMarch(xgpu::texture&& Texture) noexcept
+    {
+        if (!m_Device) return;
+        m_Device->Destroy(std::move(Texture));
+        m_Device.reset();
+    }
 }
 

--- a/Src/Details/Vulkan/xgpu_vulkan_texture.h
+++ b/Src/Details/Vulkan/xgpu_vulkan_texture.h
@@ -12,7 +12,9 @@ namespace xgpu::vulkan
         virtual int                                 getMipCount         (void)                  const   noexcept override;
         virtual xgpu::texture::format               getFormat           (void)                  const   noexcept override;
         virtual bool                                isCubemap           (void)                  const   noexcept override;
-        virtual std::array<xgpu::texture::address_mode, 3> getAdressModes(void)                  const   noexcept override;
+        virtual std::array<xgpu::texture::address_mode, 3> getAdressModes(void)                 const   noexcept override;
+
+        virtual void                                DeathMarch(xgpu::texture&& buffer)                  noexcept override;
 
         std::shared_ptr<vulkan::device> m_Device                {};
         VkImage                         m_VKImage               {};

--- a/Src/Details/xgpu_buffer_inline.h
+++ b/Src/Details/xgpu_buffer_inline.h
@@ -50,4 +50,12 @@ namespace xgpu
         return m_Private->Resize( NewEntryCount );
     }
 
+    //--------------------------------------------------------------------------------------------------------
+
+    buffer::~buffer() noexcept
+    {
+        if( m_Device )
+            m_Device->Destroy(std::move(*this));
+    }
+
 }

--- a/Src/Details/xgpu_buffer_inline.h
+++ b/Src/Details/xgpu_buffer_inline.h
@@ -9,6 +9,7 @@ namespace xgpu
             virtual xgpu::device::error*                MapUnlock       ( int StartIndex, int Count )                   noexcept = 0;
             virtual int                                 getEntryCount   ( void )                                  const noexcept = 0;
             virtual xgpu::buffer::error*                Resize          ( int NewEntryCount )                           noexcept = 0;
+            virtual void                                DeathMarch      ( xgpu::buffer&& )                              noexcept = 0;
         };
     }
 
@@ -54,8 +55,9 @@ namespace xgpu
 
     buffer::~buffer() noexcept
     {
-        if( m_Device )
-            m_Device->Destroy(std::move(*this));
+        if (!m_Private) return;
+        m_Private->DeathMarch(std::move(*this));
+        m_Private.reset();
     }
 
 }

--- a/Src/Details/xgpu_device_inline.h
+++ b/Src/Details/xgpu_device_inline.h
@@ -93,7 +93,6 @@ namespace xgpu
     , const pipeline::setup&      Setup
     ) noexcept
     {
-        Pipeline.m_Device = this;
         return m_Private->Create( Pipeline, Setup, m_Private);
     }
 
@@ -130,7 +129,6 @@ namespace xgpu
     , const texture::setup&             Setup
     ) noexcept
     {
-        Texture.m_Device = this;
         return m_Private->Create(Texture, Setup, m_Private);
     }
 
@@ -143,7 +141,6 @@ namespace xgpu
     , const pipeline_instance::setup&   Setup
     ) noexcept
     {
-        PipelineInstance.m_Device = this;
         return m_Private->Create(PipelineInstance, Setup, m_Private);
     }
 
@@ -155,7 +152,6 @@ namespace xgpu
     , const buffer::setup&      Setup 
     ) noexcept
     {
-        Buffer.m_Device = this;
         return m_Private->Create( Buffer, Setup, m_Private );
     }
 
@@ -163,22 +159,18 @@ namespace xgpu
 
     void device::Destroy(pipeline_instance&& PipelineInstance)  noexcept 
     { 
-        PipelineInstance.m_Device = nullptr;
         m_Private->Destroy( std::move(PipelineInstance) );
     }
     void device::Destroy(pipeline&& Pipeline)                   noexcept 
     {
-        Pipeline.m_Device = nullptr;
         m_Private->Destroy( std::move(Pipeline) ); 
     }
     void device::Destroy(texture&& Texture)                     noexcept 
     {
-        Texture.m_Device = nullptr;
         m_Private->Destroy( std::move(Texture) );
     }
     void device::Destroy(buffer&& Buffer)                       noexcept
     {
-        Buffer.m_Device = nullptr;
         m_Private->Destroy( std::move(Buffer) ); 
     }
 

--- a/Src/Details/xgpu_device_inline.h
+++ b/Src/Details/xgpu_device_inline.h
@@ -44,6 +44,9 @@ namespace xgpu
             virtual void Destroy(pipeline_instance&& PipelineInstance)  noexcept = 0;
             virtual void Destroy(pipeline&& Pipeline)                   noexcept = 0;
             virtual void Destroy(texture&& Texture)                     noexcept = 0;
+            virtual void Destroy(buffer&& Buffer)                       noexcept = 0;
+
+            virtual void Shutdown(void)                                 noexcept = 0;
         };
     }
 
@@ -90,6 +93,7 @@ namespace xgpu
     , const pipeline::setup&      Setup
     ) noexcept
     {
+        Pipeline.m_Device = this;
         return m_Private->Create( Pipeline, Setup, m_Private);
     }
 
@@ -126,6 +130,7 @@ namespace xgpu
     , const texture::setup&             Setup
     ) noexcept
     {
+        Texture.m_Device = this;
         return m_Private->Create(Texture, Setup, m_Private);
     }
 
@@ -138,6 +143,7 @@ namespace xgpu
     , const pipeline_instance::setup&   Setup
     ) noexcept
     {
+        PipelineInstance.m_Device = this;
         return m_Private->Create(PipelineInstance, Setup, m_Private);
     }
 
@@ -149,15 +155,36 @@ namespace xgpu
     , const buffer::setup&      Setup 
     ) noexcept
     {
+        Buffer.m_Device = this;
         return m_Private->Create( Buffer, Setup, m_Private );
     }
 
     //------------------------------------------------------------------------------------------------
 
-    void device::Destroy(pipeline_instance&& PipelineInstance)  noexcept { m_Private->Destroy( std::move(PipelineInstance) ); }
-    void device::Destroy(pipeline&& Pipeline)                   noexcept { m_Private->Destroy( std::move(Pipeline) ); }
-    void device::Destroy(texture&& Texture)                     noexcept { m_Private->Destroy( std::move(Texture) ); }
+    void device::Destroy(pipeline_instance&& PipelineInstance)  noexcept 
+    { 
+        PipelineInstance.m_Device = nullptr;
+        m_Private->Destroy( std::move(PipelineInstance) );
+    }
+    void device::Destroy(pipeline&& Pipeline)                   noexcept 
+    {
+        Pipeline.m_Device = nullptr;
+        m_Private->Destroy( std::move(Pipeline) ); 
+    }
+    void device::Destroy(texture&& Texture)                     noexcept 
+    {
+        Texture.m_Device = nullptr;
+        m_Private->Destroy( std::move(Texture) );
+    }
+    void device::Destroy(buffer&& Buffer)                       noexcept
+    {
+        Buffer.m_Device = nullptr;
+        m_Private->Destroy( std::move(Buffer) ); 
+    }
 
-
+    void device::Shutdown( void ) noexcept
+    {
+        m_Private->Shutdown();
+    }
 
 }

--- a/Src/Details/xgpu_pipeline_inline.h
+++ b/Src/Details/xgpu_pipeline_inline.h
@@ -127,4 +127,10 @@ namespace xgpu
         , .m_AlphaOperation     = op::ADD
         };
     }
+
+    pipeline::~pipeline()
+    {
+        if (m_Device)
+            m_Device->Destroy(std::move(*this));
+    }
 }

--- a/Src/Details/xgpu_pipeline_inline.h
+++ b/Src/Details/xgpu_pipeline_inline.h
@@ -5,6 +5,7 @@ namespace xgpu
         struct pipeline_handle
         {
             virtual                                    ~pipeline_handle(void)                                                    noexcept = default;
+            virtual void                                DeathMarch(xgpu::pipeline&&)                                             noexcept = 0;
         };
     }
 
@@ -130,7 +131,8 @@ namespace xgpu
 
     pipeline::~pipeline()
     {
-        if (m_Device)
-            m_Device->Destroy(std::move(*this));
+        if (!m_Private) return;
+        m_Private->DeathMarch(std::move(*this));
+        m_Private.reset();
     }
 }

--- a/Src/Details/xgpu_pipeline_instance_inline.h
+++ b/Src/Details/xgpu_pipeline_instance_inline.h
@@ -5,12 +5,12 @@ namespace xgpu
         struct pipeline_instance_handle
         {
             virtual                                    ~pipeline_instance_handle(void)                                                  noexcept = default;
+            virtual void                                DeathMarch(xgpu::pipeline_instance&&)                                           noexcept = 0;
         };
     }
 
     pipeline_instance::~pipeline_instance()
     {
-        if (m_Device)
-            m_Device->Destroy(std::move(*this));
+        m_Private->DeathMarch(std::move(*this));
     }
 }

--- a/Src/Details/xgpu_pipeline_instance_inline.h
+++ b/Src/Details/xgpu_pipeline_instance_inline.h
@@ -7,4 +7,10 @@ namespace xgpu
             virtual                                    ~pipeline_instance_handle(void)                                                  noexcept = default;
         };
     }
+
+    pipeline_instance::~pipeline_instance()
+    {
+        if (m_Device)
+            m_Device->Destroy(std::move(*this));
+    }
 }

--- a/Src/Details/xgpu_texture_inline.h
+++ b/Src/Details/xgpu_texture_inline.h
@@ -44,5 +44,11 @@ namespace xgpu
     {
         return m_Private->getAdressModes();
     }
+
+    texture::~texture(void)
+    {
+        if (m_Device)
+            m_Device->Destroy(std::move(*this));
+    }
 }
 

--- a/Src/Details/xgpu_texture_inline.h
+++ b/Src/Details/xgpu_texture_inline.h
@@ -10,6 +10,7 @@ namespace xgpu
             virtual xgpu::texture::format               getFormat               (void)                  const   noexcept = 0;
             virtual bool                                isCubemap               (void)                  const   noexcept = 0;
             virtual std::array<texture::address_mode, 3> getAdressModes         (void)                  const   noexcept = 0;
+            virtual void                                DeathMarch              (xgpu::texture&&)               noexcept = 0;
         };
     }
 
@@ -47,8 +48,9 @@ namespace xgpu
 
     texture::~texture(void)
     {
-        if (m_Device)
-            m_Device->Destroy(std::move(*this));
+        if (!m_Private) return;
+        m_Private->DeathMarch(std::move(*this));
+        m_Private.reset();
     }
 }
 

--- a/Src/xgpu_buffer.h
+++ b/Src/xgpu_buffer.h
@@ -49,6 +49,5 @@ namespace xgpu
                            ~buffer                  ( void ) noexcept;
 
         std::shared_ptr<details::buffer_handle> m_Private{};
-        device*                                 m_Device{};
     };
 }

--- a/Src/xgpu_buffer.h
+++ b/Src/xgpu_buffer.h
@@ -45,6 +45,10 @@ namespace xgpu
         [[nodiscard]]
         error*              getMappedVirtualMemory  ( T*& Pointer ) noexcept;
 
+        XGPU_INLINE
+                           ~buffer                  ( void ) noexcept;
+
         std::shared_ptr<details::buffer_handle> m_Private{};
+        device*                                 m_Device{};
     };
 }

--- a/Src/xgpu_device.h
+++ b/Src/xgpu_device.h
@@ -66,7 +66,9 @@ namespace xgpu
         XGPU_INLINE void                         Destroy        ( pipeline_instance&&               PipelineInstance ) noexcept;
         XGPU_INLINE void                         Destroy        ( pipeline&&                        Pipeline )         noexcept;
         XGPU_INLINE void                         Destroy        ( texture&&                         Texture )          noexcept;
+        XGPU_INLINE void                         Destroy        ( buffer&&                          Buffer )           noexcept;
 
+        XGPU_INLINE void                         Shutdown       ( void ) noexcept;
 
         std::shared_ptr<details::device_handle>   m_Private;
     };

--- a/Src/xgpu_pipeline.h
+++ b/Src/xgpu_pipeline.h
@@ -191,10 +191,8 @@ namespace xgpu
             pipeline::blend                     m_Blend             {};
         };
 
-
         inline ~pipeline ( void ) noexcept;
         
         std::shared_ptr<details::pipeline_handle> m_Private {};
-        device*                                   m_Device {};
     };
 }

--- a/Src/xgpu_pipeline.h
+++ b/Src/xgpu_pipeline.h
@@ -191,6 +191,10 @@ namespace xgpu
             pipeline::blend                     m_Blend             {};
         };
 
+
+        inline ~pipeline ( void ) noexcept;
+        
         std::shared_ptr<details::pipeline_handle> m_Private {};
+        device*                                   m_Device {};
     };
 }

--- a/Src/xgpu_pipeline_instance.h
+++ b/Src/xgpu_pipeline_instance.h
@@ -19,6 +19,9 @@ namespace xgpu
             std::span<sampler_binding>  m_SamplersBindings          {};
         };
         
+        inline ~pipeline_instance ( void ) noexcept;
+        
         std::shared_ptr<details::pipeline_instance_handle> m_Private;
+        device*                                            m_Device{};
     };
 }

--- a/Src/xgpu_pipeline_instance.h
+++ b/Src/xgpu_pipeline_instance.h
@@ -22,6 +22,5 @@ namespace xgpu
         inline ~pipeline_instance ( void ) noexcept;
         
         std::shared_ptr<details::pipeline_instance_handle> m_Private;
-        device*                                            m_Device{};
     };
 }

--- a/Src/xgpu_texture.h
+++ b/Src/xgpu_texture.h
@@ -92,6 +92,5 @@ namespace xgpu
         inline                     ~texture                             ( void ) noexcept;
 
         std::shared_ptr<details::texture_handle> m_Private;
-        device*                                  m_Device{};
     };
 }

--- a/Src/xgpu_texture.h
+++ b/Src/xgpu_texture.h
@@ -87,8 +87,11 @@ namespace xgpu
         bool                        isCubemap                           ( void ) const noexcept;
 
         inline
-        std::array<address_mode,3>  getAdressModes                        ( void ) const noexcept;
+        std::array<address_mode,3>  getAdressModes                      ( void ) const noexcept;
+
+        inline                     ~texture                             ( void ) noexcept;
 
         std::shared_ptr<details::texture_handle> m_Private;
+        device*                                  m_Device{};
     };
 }


### PR DESCRIPTION
* Give deathmarchable objects a raw pointer `*m_Device` to their associated `xgpu::device`. This is **not** a `std::shared_ptr`, as these objects have valid handles only as long as their associated device exists. The pointer is initialized to `nullptr` and set when function `xgpu::device::Create` is called, as that is when the object becomes associated with a device.
* When a deathmarchable `xgpu::` object that has an associated `xgpu::device` is destroyed, it calls the `xgpu::device`'s `Destroy()` function to move it into the deathmarch. To prevent infinite recursion when destroying the `std::move`d object, the `Destroy()` function sets the `xgpu::device`' pointer to `nullptr` to indicate that it is no longer dependent on a device.
* `xgpu::buffer`s are now deathmarchable so that they are always destroyed at the end of a frame. 

Examples may need to be modified to call `xgpu::device::Shutdown()` to clean up deathmarchable objects.