### PR TITLE
Add support for ImGui multi-viewport

### DIFF
--- a/source/Details/System/Windows/xgpu_windows_window.cpp
+++ b/source/Details/System/Windows/xgpu_windows_window.cpp
@@ -59,7 +59,7 @@ namespace xgpu::windows
         case WM_MOUSEMOVE:
             if( auto pWin = reinterpret_cast<windows::window*>( GetWindowLongPtr( hWnd, GWLP_USERDATA ) ); pWin )
             {
-                auto x = static_cast<const int>(lParam & 0xffff);
+                auto x = static_cast<const int>(static_cast<short>(lParam & 0xffff));
                 auto y = static_cast<const int>(lParam >> 16);
 
                 pWin->m_Mouse->m_Analog[static_cast<int>(xgpu::mouse::analog::POS_REL)][0] = x - pWin->m_Mouse->m_Analog[static_cast<int>(xgpu::mouse::analog::POS_ABS)][0];
@@ -77,7 +77,7 @@ namespace xgpu::windows
             {
                 SetCapture(hWnd);
 
-                auto x = static_cast<const int>(lParam & 0xffff);
+                auto x = static_cast<const int>(static_cast<short>(lParam & 0xffff));
                 auto y = static_cast<const int>(lParam >> 16);
 
                 pWin->m_Mouse->m_ButtonIsDown[static_cast<int>(xgpu::mouse::digital::BTN_MIDDLE)] = 1;
@@ -102,7 +102,7 @@ namespace xgpu::windows
             {
                 SetCapture(hWnd);
 
-                auto x = static_cast<const int>(lParam & 0xffff);
+                auto x = static_cast<const int>(static_cast<short>(lParam & 0xffff));
                 auto y = static_cast<const int>(lParam >> 16);
 
                 pWin->m_Mouse->m_ButtonIsDown[static_cast<int>(xgpu::mouse::digital::BTN_LEFT)] = 1;
@@ -127,7 +127,7 @@ namespace xgpu::windows
             {
                 SetCapture(hWnd);
 
-                auto x = static_cast<const int>(lParam & 0xffff);
+                auto x = static_cast<const int>(static_cast<short>(lParam & 0xffff));
                 auto y = static_cast<const int>(lParam >> 16);
 
                 pWin->m_Mouse->m_ButtonIsDown[static_cast<int>(xgpu::mouse::digital::BTN_RIGHT)] = 1;

--- a/source/Details/System/Windows/xgpu_windows_window.cpp
+++ b/source/Details/System/Windows/xgpu_windows_window.cpp
@@ -236,6 +236,11 @@ namespace xgpu::windows
                 if (wParam != 0 && pWin->m_isFrameless)
                     return 0;
             break;
+        case WM_ERASEBKGND:
+            if (auto pWin = reinterpret_cast<windows::window*>(GetWindowLongPtr(hWnd, GWLP_USERDATA)); pWin)
+                if (wParam != 0 && pWin->m_isFrameless)
+                    return true;
+            break;
         case WM_WINDOWPOSCHANGED:
             if (auto pWin = reinterpret_cast<windows::window*>(GetWindowLongPtr(hWnd, GWLP_USERDATA)); pWin)
             {

--- a/source/Details/System/Windows/xgpu_windows_window.cpp
+++ b/source/Details/System/Windows/xgpu_windows_window.cpp
@@ -231,8 +231,11 @@ namespace xgpu::windows
             if ((wParam & 0xfff0) == SC_KEYMENU) // Disable ALT application menu
                 return 0;
             break;
-
-
+        case WM_NCCALCSIZE: 
+            if (auto pWin = reinterpret_cast<windows::window*>(GetWindowLongPtr(hWnd, GWLP_USERDATA)); pWin)
+                if (wParam != 0 && pWin->m_isFrameless)
+                    return 0;
+            break;
         }    // End switch
 
         // Pass Unhandled Messages To DefWindowProc
@@ -384,6 +387,7 @@ namespace xgpu::windows
         m_Height   = Setup.m_Height;
         m_Mouse    = Instance.m_Mouse;
         m_Keyboard = Instance.m_Keyboard;
+        m_isFrameless = Setup.m_bFrameless;
 
         //
         // Allow us to track the mouse outside the window (get WM_INPUT messages) for the mouse

--- a/source/Details/System/Windows/xgpu_windows_window.cpp
+++ b/source/Details/System/Windows/xgpu_windows_window.cpp
@@ -7,7 +7,7 @@ namespace xgpu::windows
         switch( uMsg )
         {
         case WM_CLOSE:
-            PostMessage( hWnd, WM_QUIT, 0, 0 );
+            PostMessage( hWnd, WM_QUIT, 0, 0 ); 
             return 0;
 
         case WM_PAINT:
@@ -406,5 +406,10 @@ namespace xgpu::windows
         }
 
         return nullptr;
+    }
+
+    window::~window()
+    {
+        DestroyWindow(m_hWindow);
     }
 }

--- a/source/Details/System/Windows/xgpu_windows_window.cpp
+++ b/source/Details/System/Windows/xgpu_windows_window.cpp
@@ -236,6 +236,15 @@ namespace xgpu::windows
                 if (wParam != 0 && pWin->m_isFrameless)
                     return 0;
             break;
+        case WM_WINDOWPOSCHANGED:
+            if (auto pWin = reinterpret_cast<windows::window*>(GetWindowLongPtr(hWnd, GWLP_USERDATA)); pWin)
+            {
+                WINDOWPOS* wpos = (WINDOWPOS*) lParam;
+
+                pWin->m_Mouse->m_Analog[static_cast<int>(xgpu::mouse::analog::POS_ABS)][0] += pWin->m_TruePosition.first - wpos->x;
+                pWin->m_Mouse->m_Analog[static_cast<int>(xgpu::mouse::analog::POS_ABS)][1] += pWin->m_TruePosition.second - wpos->y;
+                pWin->m_TruePosition = { wpos->x, wpos->y };
+            }
         }    // End switch
 
         // Pass Unhandled Messages To DefWindowProc

--- a/source/Details/System/Windows/xgpu_windows_window.h
+++ b/source/Details/System/Windows/xgpu_windows_window.h
@@ -93,5 +93,6 @@ namespace xgpu::windows
         bool                                        m_isResized { false };
         
         bool                                        m_isFrameless{ false };
+        std::pair<int, int>                         m_TruePosition{};
     };
 }

--- a/source/Details/System/Windows/xgpu_windows_window.h
+++ b/source/Details/System/Windows/xgpu_windows_window.h
@@ -77,6 +77,8 @@ namespace xgpu::windows
             SetCursorPos(x, y);
         }
 
+        virtual                        ~window();
+
         HWND                                        m_hWindow   { 0 };
         std::shared_ptr<xgpu::windows::keyboard>    m_Keyboard;
         std::shared_ptr<xgpu::windows::mouse>       m_Mouse;

--- a/source/Details/System/Windows/xgpu_windows_window.h
+++ b/source/Details/System/Windows/xgpu_windows_window.h
@@ -77,6 +77,11 @@ namespace xgpu::windows
             SetCursorPos(x, y);
         }
 
+        void                            setFrameless(bool frameless)                                        noexcept
+        {
+            m_isFrameless = frameless;
+        }
+
         virtual                        ~window();
 
         HWND                                        m_hWindow   { 0 };
@@ -86,5 +91,7 @@ namespace xgpu::windows
         int                                         m_Height    { 0 };
         bool                                        m_isMinimize{ false };
         bool                                        m_isResized { false };
+        
+        bool                                        m_isFrameless{ false };
     };
 }

--- a/source/Details/Vulkan/xgpu_vulkan_device.cpp
+++ b/source/Details/Vulkan/xgpu_vulkan_device.cpp
@@ -396,9 +396,13 @@ namespace xgpu::vulkan
     { 
         m_DeathMarchList[m_FrameIndex % m_DeathMarchList.size()].m_Pipeline.push_back(std::move(Pipeline)); 
     }
-    void device::Destroy(xgpu::buffer&& Buffer)                       noexcept 
-    { 
-        m_DeathMarchList[m_FrameIndex % m_DeathMarchList.size()].m_Buffer.push_back(std::move(Buffer)); 
+    void device::Destroy(xgpu::buffer&& Buffer)                       noexcept
+    {
+        m_DeathMarchList[m_FrameIndex % m_DeathMarchList.size()].m_Buffer.push_back(std::move(Buffer));
+    }
+    void device::Destroy(xgpu::window&& Window)                       noexcept
+    {
+        m_DeathMarchList[m_FrameIndex % m_DeathMarchList.size()].m_Window.push_back(std::move(Window));
     }
 
     //----------------------------------------------------------------------------------------------------------
@@ -458,6 +462,13 @@ namespace xgpu::vulkan
         {
             DeathMarch.m_Buffer.clear();
         }
+
+        if (false == DeathMarch.m_Window.empty())
+        {
+            DeathMarch.m_Window.clear();
+        }
+
+
     }
 
     void device::Shutdown(void) noexcept

--- a/source/Details/Vulkan/xgpu_vulkan_device.h
+++ b/source/Details/Vulkan/xgpu_vulkan_device.h
@@ -70,6 +70,7 @@ namespace xgpu::vulkan
         virtual void                    Destroy             ( xgpu::pipeline&& Pipeline )                   noexcept override;
         virtual void                    Destroy             ( xgpu::texture&& Texture )                     noexcept override;
         virtual void                    Destroy             ( xgpu::buffer&& Buffer )                       noexcept override;
+        virtual void                    Destroy             ( xgpu::window&& Window )                       noexcept override;
 
 
         struct death_march
@@ -78,6 +79,7 @@ namespace xgpu::vulkan
             std::vector<xgpu::pipeline_instance>  m_PipelineInstance;
             std::vector<xgpu::pipeline>           m_Pipeline;
             std::vector<xgpu::buffer>             m_Buffer;
+            std::vector<xgpu::window>             m_Window;
         };
 
         using mati_per_renderpass_map = std::unordered_map<std::uint64_t, pipeline_instance::per_renderpass>;

--- a/source/Details/Vulkan/xgpu_vulkan_window.cpp
+++ b/source/Details/Vulkan/xgpu_vulkan_window.cpp
@@ -1516,4 +1516,11 @@ namespace xgpu::vulkan
         m_VKClearValue[0] = VkClearValue{ .color = {.float32 = {R,G,B,A}}};
     }
 
+    //------------------------------------------------------------------------------------------------------------------------
+    void window::DeathMarch(xgpu::window&& Window) noexcept
+    {
+        if (!m_Device) return;
+        m_Device->Destroy(std::move(Window));
+        m_Device.reset();
+    }
 }

--- a/source/Details/Vulkan/xgpu_vulkan_window.h
+++ b/source/Details/Vulkan/xgpu_vulkan_window.h
@@ -114,6 +114,9 @@ namespace xgpu::vulkan
         xgpu::device                            getDevice                   ( void
                                                                             ) const noexcept override;
 
+        void                                    DeathMarch                  ( xgpu::window&& window 
+                                                                            ) noexcept override;
+
         std::shared_ptr<vulkan::device>         m_Device                {};
         VkSurfaceKHR                            m_VKSurface             {};
         std::array<VkClearValue,2>              m_VKClearValue          { VkClearValue{ .color = {.float32 = {0,0,0,1}} }, VkClearValue{ .depthStencil{ 1.0f, 0 } }};

--- a/source/Details/xgpu_device_inline.h
+++ b/source/Details/xgpu_device_inline.h
@@ -45,6 +45,7 @@ namespace xgpu
             virtual void Destroy(pipeline&& Pipeline)                   noexcept = 0;
             virtual void Destroy(texture&& Texture)                     noexcept = 0;
             virtual void Destroy(buffer&& Buffer)                       noexcept = 0;
+            virtual void Destroy(window&& Window)                       noexcept = 0;
 
             virtual void Shutdown(void)                                 noexcept = 0;
         };
@@ -171,7 +172,11 @@ namespace xgpu
     }
     void device::Destroy(buffer&& Buffer)                       noexcept
     {
-        m_Private->Destroy( std::move(Buffer) ); 
+        m_Private->Destroy( std::move(Buffer) );
+    }
+    void device::Destroy(window&& Window)                       noexcept
+    {
+        m_Private->Destroy( std::move(Window) ); 
     }
 
     void device::Shutdown( void ) noexcept

--- a/source/Details/xgpu_window_inline.h
+++ b/source/Details/xgpu_window_inline.h
@@ -33,6 +33,7 @@ namespace xgpu
             virtual     xgpu::device                    getDevice               ( void ) const                                              noexcept = 0;
             virtual     void                            setMousePosition        ( int x, int y )                                            noexcept = 0;
 
+            virtual     void                            DeathMarch              ( xgpu::window&& Window )                                   noexcept = 0;
 
 //            virtual     bool                            HandleEvents(void)                                                    noexcept = 0;
             //            virtual     void                            BeginRender             ( const eng_view& View, const bool bUpdateViewPort = true ) noexcept = 0;
@@ -187,5 +188,14 @@ namespace xgpu
     void window::getDevice( xgpu::device& Device ) const noexcept
     {
         Device = m_Private->getDevice();
+    }
+
+
+    window::~window()
+    {
+        if (m_Private.use_count() > 1) return;
+        if (!m_Private) return;
+        m_Private->DeathMarch(std::move(*this));
+        m_Private.reset();
     }
 }

--- a/source/Examples/E03_ImguiBreatch/E03_ImguiBreach.cpp
+++ b/source/Examples/E03_ImguiBreatch/E03_ImguiBreach.cpp
@@ -37,7 +37,7 @@ int E03_Example()
     //
     while (Instance.ProcessInputEvents())
     {
-        if( xgpu::tools::imgui::BeginRendering() )
+        if( xgpu::tools::imgui::BeginRendering(true) )
             continue;
 
         //

--- a/source/Tools/xgpu_imgui_breach.cpp
+++ b/source/Tools/xgpu_imgui_breach.cpp
@@ -1294,10 +1294,12 @@ void CreateChildWindow( ImGuiViewport* pViewport ) noexcept
     GETINSTANCE;
     auto pInfo = new window_info();
     xgpu::window::setup Setup;
-    Setup.m_Width   = static_cast<int>(pViewport->Size.x);
-    Setup.m_Height  = static_cast<int>(pViewport->Size.y);
-    Setup.m_X       = static_cast<int>(pViewport->Pos.x);
-    Setup.m_Y       = static_cast<int>(pViewport->Pos.y);
+    Setup.m_Width       = static_cast<int>(pViewport->Size.x);
+    Setup.m_Height      = static_cast<int>(pViewport->Size.y);
+    Setup.m_X           = static_cast<int>(pViewport->Pos.x);
+    Setup.m_Y           = static_cast<int>(pViewport->Pos.y);
+    Setup.m_bFrameless  = true;
+
     if (auto Err = Instance.m_Shared->m_Device.Create(pInfo->m_Window, Setup))
     {
         printf("Failed to create child window: %s\n", Err );

--- a/source/Tools/xgpu_imgui_breach.cpp
+++ b/source/Tools/xgpu_imgui_breach.cpp
@@ -1102,7 +1102,7 @@ struct breach_instance : window_info
                         if ( io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable )
                         {
                             auto [WindowX, WindowY] = Info.m_Window.getPosition();
-                            //printf("Mouse[%d  %d]  Win+Mouse(%d  %d)\n", int(MouseValues[0]), int(MouseValues[1]), int(WindowX + MouseValues[0]), int(WindowY + MouseValues[1]));
+                            printf("Mouse[%d  %d]  Win+Mouse(%d  %d)\n", int(MouseValues[0]), int(MouseValues[1]), int(WindowX + MouseValues[0]), int(WindowY + MouseValues[1]));
 
                             // Multi-viewport mode: mouse position in OS absolute coordinates (io.MousePos is (0,0) when the mouse is on the upper-left of the primary monitor)
                             //io.MousePos = ImVec2( (float)WindowX + MouseValues[0], (float)WindowY + MouseValues[1] );

--- a/source/Tools/xgpu_imgui_breach.cpp
+++ b/source/Tools/xgpu_imgui_breach.cpp
@@ -657,8 +657,8 @@ struct window_info
     window_info( void ) noexcept
     : m_Shared{ share_resources::getOrCreate() }
     {
-        auto Err = m_Shared->m_Device.Create(m_Window, {});
-        assert( Err == nullptr );
+        //auto Err = m_Shared->m_Device.Create(m_Window, {});
+        //assert( Err == nullptr );
         InitializeBuffers();
     }
 
@@ -1393,6 +1393,7 @@ void RenderChildWindow(ImGuiViewport* pViewport, void*) noexcept
 {
     GETINSTANCE;
     auto& Info = *reinterpret_cast<window_info*>(pViewport->RendererUserData);
+    Info.m_Window.BeginRendering();
     Info.Render( io, pViewport->DrawData );
 }
 
@@ -1401,6 +1402,7 @@ void RenderChildWindow(ImGuiViewport* pViewport, void*) noexcept
 static
 void ChildSwapBuffers(ImGuiViewport* pViewport, void*) noexcept
 {
+    GETINSTANCE;
     auto& Info = *reinterpret_cast<window_info*>(pViewport->RendererUserData);
     Info.m_Window.PageFlip();
 }
@@ -1436,7 +1438,7 @@ xgpu::device::error* CreateInstance( xgpu::window& MainWindow ) noexcept
     io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;       // Enable Keyboard Controls
     io.ConfigFlags &= ~ImGuiConfigFlags_NavEnableGamepad;      // Enable Gamepad Controls
     io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;           // Enable Docking
-    io.ConfigFlags &= ~ImGuiConfigFlags_ViewportsEnable;         // Enable Multi-Viewport / Platform Windows
+    io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;         // Enable Multi-Viewport / Platform Windows
     io.BackendRendererName = "xgpu_imgui_breach";
     io.BackendFlags |= ImGuiBackendFlags_RendererHasVtxOffset;  // We can honor the ImDrawCmd::VtxOffset field, allowing for large meshes.
 
@@ -1446,8 +1448,8 @@ xgpu::device::error* CreateInstance( xgpu::window& MainWindow ) noexcept
     //ImGui::ClearIniSettings();
     //printf("SettingsIniData after clear: %s\n", ImGui::GetCurrentContext()->SettingsIniData.c_str());
 
-  //  io.BackendFlags |= ImGuiBackendFlags_RendererHasViewports;  // We can create multi-viewports on the Renderer side (optional)
- //   io.BackendFlags |= ImGuiBackendFlags_PlatformHasViewports;  // We can create multi-viewports on the Platform side (optional)
+    io.BackendFlags |= ImGuiBackendFlags_RendererHasViewports;  // We can create multi-viewports on the Renderer side (optional)
+    io.BackendFlags |= ImGuiBackendFlags_PlatformHasViewports;  // We can create multi-viewports on the Platform side (optional)
     //io.ConfigViewportsNoAutoMerge = true;
     //io.ConfigViewportsNoTaskBarIcon = true;
 
@@ -1505,8 +1507,8 @@ xgpu::device::error* CreateInstance( xgpu::window& MainWindow ) noexcept
     if (io.ConfigFlags & ImGuiConfigFlags_ViewportsEnable)
     {
         ImGuiPlatformIO& platform_io = ImGui::GetPlatformIO();
-        platform_io.Renderer_CreateWindow       = CreateChildWindow;
-        platform_io.Renderer_DestroyWindow      = DestroyChildWindow;
+        platform_io.Renderer_CreateWindow       = [](ImGuiViewport* pViewport) {}; //CreateChildWindow;
+        platform_io.Renderer_DestroyWindow      = [](ImGuiViewport* pViewport) {}; //DestroyChildWindow;
         platform_io.Renderer_SetWindowSize      = SetChildWindowSize;
         platform_io.Renderer_RenderWindow       = RenderChildWindow;
         platform_io.Renderer_SwapBuffers        = ChildSwapBuffers;
@@ -1519,8 +1521,8 @@ xgpu::device::error* CreateInstance( xgpu::window& MainWindow ) noexcept
         platform_io.Platform_SetWindowSize      = SetChildWindowSize;
         platform_io.Platform_GetWindowSize      = GetChildWindowSize;
         platform_io.Platform_SetWindowTitle     = [](ImGuiViewport* pViewport, const char*){};
-        platform_io.Platform_RenderWindow       = RenderChildWindow;
-        platform_io.Platform_SwapBuffers        = ChildSwapBuffers;
+        platform_io.Platform_RenderWindow       = [](ImGuiViewport* pViewport, void*) {}; // RenderChildWindow;
+        platform_io.Platform_SwapBuffers        = [](ImGuiViewport* pViewport, void*) {}; // ChildSwapBuffers;
 
 
         platform_io.Platform_SetWindowFocus = [](ImGuiViewport* pViewport)

--- a/source/xgpu_device.h
+++ b/source/xgpu_device.h
@@ -67,6 +67,7 @@ namespace xgpu
         XGPU_INLINE void                         Destroy        ( pipeline&&                        Pipeline )         noexcept;
         XGPU_INLINE void                         Destroy        ( texture&&                         Texture )          noexcept;
         XGPU_INLINE void                         Destroy        ( buffer&&                          Buffer )           noexcept;
+        XGPU_INLINE void                         Destroy        ( window&&                          Window )           noexcept;
 
         XGPU_INLINE void                         Shutdown       ( void ) noexcept;
 

--- a/source/xgpu_window.h
+++ b/source/xgpu_window.h
@@ -17,6 +17,10 @@ namespace xgpu
             float               m_ClearColorA   { 1.0f };
         };
 
+
+        XGPU_INLINE                                     window                  ( void ) = default;
+        XGPU_INLINE                                    ~window                  ( void ) noexcept;
+
         XGPU_INLINE [[nodiscard]]   bool                isValid                 ( void ) const noexcept;
         XGPU_INLINE [[nodiscard]]   int                 getWidth                ( void ) const noexcept;
         XGPU_INLINE [[nodiscard]]   int                 getHeight               ( void ) const noexcept;

--- a/source/xgpu_window.h
+++ b/source/xgpu_window.h
@@ -11,6 +11,7 @@ namespace xgpu
             bool                m_bFullScreen   { false };
             bool                m_bClearOnRender{ true };
             bool                m_bSyncOn       { false };
+            bool                m_bFrameless    { false };
             float               m_ClearColorR   { 0.45f };
             float               m_ClearColorG   { 0.45f };
             float               m_ClearColorB   { 0.45f };


### PR DESCRIPTION
**Work in progress.**

* Make `xgpu::window` and its associated handle deathmarchable. This prevents windows from being destroyed while input events are still associated with them.
* Add destructor for `xgpu::windows::window` that closes the associated WinAPI window.
* `window_info` no longer creates a new `xgpu::window` in its default constructor. 
* WinAPI windows can now be created "frameless" (i.e. without the OS default window frame).
* Fix a bug where the _x_-coordinate of the mouse position would wrap around to 65535 instead of going negative. _x_-coordinate is now properly sign-extended as a 16-bit number.
* Implement a workaround for window position and mouse position coordinates updating separately for WinAPI windows.

**To do:**
* Preserve drag state when moving an ImGui window out of the main OS window.
* Fix a bug where resizing an ImGui window causes it to flash white.
* Mouse events should be calculated relative to the hovered window, not the focused window.