### PR TITLE
Fix bugs with ImGui rendering

### DIFF
--- a/source/Details/System/Windows/xgpu_windows_window.h
+++ b/source/Details/System/Windows/xgpu_windows_window.h
@@ -30,7 +30,12 @@ namespace xgpu::windows
             return m_hWindow == GetFocus();
         }
 
-        virtual     void                            setFocus(void) const                                                noexcept override
+        virtual     bool                            isCapturing(void) const                                            noexcept override
+        {
+            return m_hWindow == GetCapture();
+        }
+
+        virtual     void                            setFocus(void) const                                               noexcept override
         {
             SetFocus(m_hWindow);
         }

--- a/source/Details/Vulkan/xgpu_vulkan_window.h
+++ b/source/Details/Vulkan/xgpu_vulkan_window.h
@@ -117,6 +117,8 @@ namespace xgpu::vulkan
         void                                    DeathMarch                  ( xgpu::window&& window 
                                                                             ) noexcept override;
 
+                                               ~window                      ( void );
+
         std::shared_ptr<vulkan::device>         m_Device                {};
         VkSurfaceKHR                            m_VKSurface             {};
         std::array<VkClearValue,2>              m_VKClearValue          { VkClearValue{ .color = {.float32 = {0,0,0,1}} }, VkClearValue{ .depthStencil{ 1.0f, 0 } }};
@@ -140,5 +142,6 @@ namespace xgpu::vulkan
         int                                     m_nCmds                 {0};
         VkViewport                              m_DefaultViewport       {};
         VkRect2D                                m_DefaultScissor        {};
+        bool                                    m_bDeathMarched         {false};
     };
 }

--- a/source/Details/xgpu_window_inline.h
+++ b/source/Details/xgpu_window_inline.h
@@ -26,6 +26,7 @@ namespace xgpu
             virtual     void                            setClearColor           ( float R, float G, float B, float A )                      noexcept = 0;
             virtual     std::size_t                     getSystemWindowHandle   ( void ) const                                              noexcept = 0;
             virtual     bool                            isFocused               ( void ) const                                              noexcept = 0;
+            virtual     bool                            isCapturing             ( void ) const                                              noexcept = 0;
             virtual     void                            setFocus                ( void ) const                                              noexcept = 0;
             virtual     std::pair<int, int>             getPosition             ( void ) const                                              noexcept = 0;
             virtual     void                            setPosition             ( int x, int y )                                            noexcept = 0;
@@ -137,11 +138,21 @@ namespace xgpu
 
     //--------------------------------------------------------------------------
 
+    XGPU_INLINE [[nodiscard]] bool
+    window::isCapturing(void) const noexcept
+    {
+        return m_Private->isCapturing();
+    }
+
+    //--------------------------------------------------------------------------
+
     XGPU_INLINE
     void window::setFocus(void) const noexcept
     {
         return m_Private->setFocus();
     }
+
+    //--------------------------------------------------------------------------
 
     XGPU_INLINE
     [[nodiscard]] bool

--- a/source/Tools/xgpu_imgui_breach.cpp
+++ b/source/Tools/xgpu_imgui_breach.cpp
@@ -1188,13 +1188,21 @@ struct breach_instance : window_info
         }
 
         // Focus events (check if window focus changed)
-        static bool was_focused = false;
-        bool is_focused = m_Window.isFocused(); // Assuming xGPU provides a focus check
-        if (is_focused != was_focused)
         {
-            io.AddFocusEvent(is_focused);
-            printf("Window Focus: %s\n", is_focused ? "Gained" : "Lost");
-            was_focused = is_focused;
+            ImGuiPlatformIO& PlatformIO = ImGui::GetPlatformIO();
+            static bool was_focused = false;
+            bool is_focused = false;
+            for (auto& vp : PlatformIO.Viewports)
+            {
+                auto& Info = *reinterpret_cast<window_info*>(vp->RendererUserData);
+                is_focused = is_focused || Info.m_Window.isFocused();
+            }
+            if (is_focused != was_focused)
+            {
+                io.AddFocusEvent(is_focused);
+                printf("Window Focus: %s\n", is_focused ? "Gained" : "Lost");
+                was_focused = is_focused;
+            }
         }
 
         // Start the frame

--- a/source/Tools/xgpu_imgui_breach.cpp
+++ b/source/Tools/xgpu_imgui_breach.cpp
@@ -1089,9 +1089,9 @@ struct breach_instance : window_info
                 const bool focused = true;
                 IM_ASSERT(platform_io.Viewports.Size == 1);
 #else
-                const bool bFocused = Info.m_Window.isFocused();
+                const bool bCapturing = Info.m_Window.isCapturing();
 #endif
-                if(bFocused)
+                if(bCapturing)
                 {
                     if (io.WantSetMousePos)
                     {
@@ -1299,6 +1299,7 @@ void CreateChildWindow( ImGuiViewport* pViewport ) noexcept
     Setup.m_X           = static_cast<int>(pViewport->Pos.x);
     Setup.m_Y           = static_cast<int>(pViewport->Pos.y);
     Setup.m_bFrameless  = true;
+    Setup.m_bFocus      = false;
 
     if (auto Err = Instance.m_Shared->m_Device.Create(pInfo->m_Window, Setup))
     {
@@ -1511,7 +1512,7 @@ xgpu::device::error* CreateInstance( xgpu::window& MainWindow ) noexcept
         ImGuiPlatformIO& platform_io = ImGui::GetPlatformIO();
         platform_io.Renderer_CreateWindow       = [](ImGuiViewport* pViewport) {}; //CreateChildWindow;
         platform_io.Renderer_DestroyWindow      = [](ImGuiViewport* pViewport) {}; //DestroyChildWindow;
-        platform_io.Renderer_SetWindowSize      = SetChildWindowSize;
+        platform_io.Renderer_SetWindowSize      = [](ImGuiViewport* pViewport, ImVec2) {}; //SetChildWindowSize;
         platform_io.Renderer_RenderWindow       = RenderChildWindow;
         platform_io.Renderer_SwapBuffers        = ChildSwapBuffers;
 

--- a/source/xgpu_window.h
+++ b/source/xgpu_window.h
@@ -12,6 +12,7 @@ namespace xgpu
             bool                m_bClearOnRender{ true };
             bool                m_bSyncOn       { false };
             bool                m_bFrameless    { false };
+            bool                m_bFocus        { true };
             float               m_ClearColorR   { 0.45f };
             float               m_ClearColorG   { 0.45f };
             float               m_ClearColorB   { 0.45f };
@@ -32,6 +33,7 @@ namespace xgpu
         XGPU_INLINE                 void                setClearColor           ( float R, float G, float B, float A ) noexcept;
         XGPU_INLINE [[nodiscard]]   std::size_t         getSystemWindowHandle   ( void ) const noexcept;
         XGPU_INLINE [[nodiscard]]   bool                isFocused               ( void ) const noexcept;
+        XGPU_INLINE [[nodiscard]]   bool                isCapturing             ( void ) const noexcept;
         XGPU_INLINE                 void                setFocus                ( void ) const noexcept;
         XGPU_INLINE [[nodiscard]]   bool                isMinimized             ( void ) const noexcept;
         XGPU_INLINE [[nodiscard]]   std::pair<int,int>  getPosition             ( void ) const noexcept;


### PR DESCRIPTION
This pull request makes the following bugfixes:

* `xgpu::vulkan::window`s now clean up their associated Vulkan structures on deletion.
* ImGui focus lost events don't fire unless all ImGui window are unfocused.
  * This also fixes ImGui windows needing to be reselected when dragging out of the main window.
* ImGui mouse position events now fire based on the capturing window, not the focused one.

The following changes were also made:

* Windows can now be created frameless by default.