### PR TITLE
Fix xgpu::windows::window mouse capturing bug

### DIFF
--- a/source/Details/System/Windows/xgpu_windows_window.cpp
+++ b/source/Details/System/Windows/xgpu_windows_window.cpp
@@ -7,7 +7,7 @@ namespace xgpu::windows
         switch( uMsg )
         {
         case WM_CLOSE:
-            PostMessage( hWnd, WM_QUIT, 0, 0 ); 
+            PostMessage( hWnd, WM_QUIT, 0, 0 );  // should this be a call to PostQuitMessage instead?
             return 0;
 
         case WM_PAINT:
@@ -59,8 +59,7 @@ namespace xgpu::windows
         case WM_MOUSEMOVE:
             if( auto pWin = reinterpret_cast<windows::window*>( GetWindowLongPtr( hWnd, GWLP_USERDATA ) ); pWin )
             {
-                SetCapture(hWnd);
-
+                
                 auto x = static_cast<const int>(static_cast<short>(lParam & 0xffff));
                 auto y = static_cast<const int>(lParam >> 16);
 
@@ -72,12 +71,30 @@ namespace xgpu::windows
 
                 pWin->m_Mouse->m_Analog[static_cast<int>(xgpu::mouse::analog::WHEEL_REL)][0] = 0;
                 pWin->m_Mouse->m_Analog[static_cast<int>(xgpu::mouse::analog::WHEEL_REL)][1] = 0;
+
+                if (false == pWin->m_isHovered)
+                {
+                    TRACKMOUSEEVENT trackMouseEvent{
+                        .cbSize = sizeof(TRACKMOUSEEVENT),
+                        .dwFlags = TME_LEAVE,
+                        .hwndTrack = hWnd
+                    };
+                    TrackMouseEvent(&trackMouseEvent);
+                    pWin->m_isHovered = true;
+                }
+            }
+            break;
+        case WM_MOUSELEAVE:
+            if (auto pWin = reinterpret_cast<windows::window*>(GetWindowLongPtr(hWnd, GWLP_USERDATA)); pWin)
+            {
+                pWin->m_isHovered = false;
             }
             break;
         case WM_MBUTTONDOWN:
             if( auto pWin = reinterpret_cast<windows::window*>( GetWindowLongPtr( hWnd, GWLP_USERDATA ) ); pWin )
             {
                 SetCapture(hWnd);
+                SetFocus(hWnd);
 
                 auto x = static_cast<const int>(static_cast<short>(lParam & 0xffff));
                 auto y = static_cast<const int>(lParam >> 16);
@@ -103,6 +120,7 @@ namespace xgpu::windows
             if( auto pWin = reinterpret_cast<windows::window*>( GetWindowLongPtr( hWnd, GWLP_USERDATA ) ); pWin )
             {
                 SetCapture(hWnd);
+                SetFocus(hWnd);
 
                 auto x = static_cast<const int>(static_cast<short>(lParam & 0xffff));
                 auto y = static_cast<const int>(lParam >> 16);
@@ -128,6 +146,7 @@ namespace xgpu::windows
             if( auto pWin = reinterpret_cast<windows::window*>( GetWindowLongPtr( hWnd, GWLP_USERDATA ) ); pWin )
             {
                 SetCapture(hWnd);
+                SetFocus(hWnd);
 
                 auto x = static_cast<const int>(static_cast<short>(lParam & 0xffff));
                 auto y = static_cast<const int>(lParam >> 16);
@@ -240,7 +259,7 @@ namespace xgpu::windows
             break;
         case WM_ERASEBKGND:
             if (auto pWin = reinterpret_cast<windows::window*>(GetWindowLongPtr(hWnd, GWLP_USERDATA)); pWin)
-                if (wParam != 0 && pWin->m_isFrameless)
+                if (wParam != 0)
                     return true;
             break;
         case WM_WINDOWPOSCHANGED:

--- a/source/Details/System/Windows/xgpu_windows_window.h
+++ b/source/Details/System/Windows/xgpu_windows_window.h
@@ -35,6 +35,11 @@ namespace xgpu::windows
             return m_hWindow == GetCapture();
         }
 
+        virtual     bool                            isHovered(void) const                                              noexcept override
+        {
+            return m_isHovered;
+        }
+
         virtual     void                            setFocus(void) const                                               noexcept override
         {
             SetFocus(m_hWindow);
@@ -98,6 +103,7 @@ namespace xgpu::windows
         bool                                        m_isResized { false };
         
         bool                                        m_isFrameless{ false };
+        bool                                        m_isHovered{ false };
         std::pair<int, int>                         m_TruePosition{};
     };
 }

--- a/source/Details/Vulkan/xgpu_vulkan_window.cpp
+++ b/source/Details/Vulkan/xgpu_vulkan_window.cpp
@@ -1526,6 +1526,12 @@ namespace xgpu::vulkan
 
     window::~window(void)
     {
+        if (auto VKErr = vkDeviceWaitIdle(m_Device->m_VKDevice); VKErr)
+        {
+            m_Device->m_Instance->ReportError(VKErr, "Fail to wait for device");
+            // We will pretend that there was actually no error since this function is used for run time...
+        }
+
         VkAllocationCallbacks* pAllocator = m_Device->m_Instance->m_pVKAllocator;
         if (m_Frames.get())
         {

--- a/source/Details/xgpu_window_inline.h
+++ b/source/Details/xgpu_window_inline.h
@@ -27,6 +27,7 @@ namespace xgpu
             virtual     std::size_t                     getSystemWindowHandle   ( void ) const                                              noexcept = 0;
             virtual     bool                            isFocused               ( void ) const                                              noexcept = 0;
             virtual     bool                            isCapturing             ( void ) const                                              noexcept = 0;
+            virtual     bool                            isHovered               ( void ) const                                              noexcept = 0;
             virtual     void                            setFocus                ( void ) const                                              noexcept = 0;
             virtual     std::pair<int, int>             getPosition             ( void ) const                                              noexcept = 0;
             virtual     void                            setPosition             ( int x, int y )                                            noexcept = 0;
@@ -142,6 +143,14 @@ namespace xgpu
     window::isCapturing(void) const noexcept
     {
         return m_Private->isCapturing();
+    }
+
+    //--------------------------------------------------------------------------
+
+    XGPU_INLINE [[nodiscard]] bool
+    window::isHovered(void) const noexcept
+    {
+        return m_Private->isHovered();
     }
 
     //--------------------------------------------------------------------------

--- a/source/Tools/xgpu_imgui_breach.cpp
+++ b/source/Tools/xgpu_imgui_breach.cpp
@@ -1089,9 +1089,9 @@ struct breach_instance : window_info
                 const bool focused = true;
                 IM_ASSERT(platform_io.Viewports.Size == 1);
 #else
-                const bool bCapturing = Info.m_Window.isCapturing();
+                const bool bHovered = Info.m_Window.isHovered();
 #endif
-                if(bCapturing)
+                if(bHovered)
                 {
                     if (io.WantSetMousePos)
                     {
@@ -1557,8 +1557,8 @@ xgpu::device::error* CreateInstance( xgpu::window& MainWindow ) noexcept
 
         platform_io.Monitors.resize(0);
         ImGuiPlatformMonitor monitor;
-        monitor.MainPos = monitor.WorkPos = ImVec2((float)0, (float)0);
-        monitor.MainSize = monitor.WorkSize = ImVec2((float)4000.0f, (float)4000.0f);
+        monitor.MainPos = monitor.WorkPos = ImVec2((float)-5000.0f, (float)-5000.0f);
+        monitor.MainSize = monitor.WorkSize = ImVec2((float)10000.0f, (float)10000.0f);
         platform_io.Monitors.push_back(monitor);
     }
 

--- a/source/xgpu_window.h
+++ b/source/xgpu_window.h
@@ -34,6 +34,7 @@ namespace xgpu
         XGPU_INLINE [[nodiscard]]   std::size_t         getSystemWindowHandle   ( void ) const noexcept;
         XGPU_INLINE [[nodiscard]]   bool                isFocused               ( void ) const noexcept;
         XGPU_INLINE [[nodiscard]]   bool                isCapturing             ( void ) const noexcept;
+        XGPU_INLINE [[nodiscard]]   bool                isHovered               ( void ) const noexcept;
         XGPU_INLINE                 void                setFocus                ( void ) const noexcept;
         XGPU_INLINE [[nodiscard]]   bool                isMinimized             ( void ) const noexcept;
         XGPU_INLINE [[nodiscard]]   std::pair<int,int>  getPosition             ( void ) const noexcept;


### PR DESCRIPTION
* Changed `xgpu::windows::window`'s hovered window testing to request and use `WM_MOUSELEAVE` instead of using WinAPI function `SetCapture`
* Resized the ImGui working space to be a 10,000 by 10,000 pixel area centered on the top left of the primary monitor